### PR TITLE
add start month picker compatibility for Firefox and Safari

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -37,6 +37,12 @@ function Sidebar({
 	const maxGroups = getMaxGroups(isProUser);
 	const [newEventName, setNewEventName] = useState("");
 	const [editingGroup, setEditingGroup] = useState<EventGroup | null>(null);
+	const [rawStartDate, setRawStartDate] = useState<string>(format(startDate, "yyyy-MM"))
+
+	const isValidDate = (rawDate: string): boolean => {
+		const [year, month] = rawDate.split("-");
+		return year.length === 4 && typeof month !== "undefined" && month.length === 2;
+	}
 
 	// Add effect to select the first group if none is selected
 	useEffect(() => {
@@ -85,9 +91,10 @@ function Sidebar({
 	};
 
 	const handleStartDateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+		setRawStartDate(e.target.value)
 		try {
-			const [year, month] = e.target.value.split("-").map(Number);
-			if (year && month) {
+			if (isValidDate(e.target.value)) {
+				const [year, month] = e.target.value.split('-').map(Number)
 				const newDate = new Date(year, month - 1, 1);
 				setStartDate(newDate);
 			}
@@ -256,7 +263,7 @@ function Sidebar({
 					<input
 						type="month"
 						id="start-date"
-						value={format(startDate, "yyyy-MM")}
+						value={isValidDate(rawStartDate) ? format(startDate, "yyyy-MM") : rawStartDate}
 						onChange={handleStartDateChange}
 					/>
 				</div>


### PR DESCRIPTION
## Issue description

Input type "month" is not available on Firefox and Safari. Instead, it is displayed as a text input.

The component then breaks because trying to input a new number will produce a 3 digit month, which will the Date constructor is added as years & months. For example here, trying to input 0 after 08 (for august) produces 080 months, which is 6 years & 8 months.

![Aug-07-2025 09-40-22](https://github.com/user-attachments/assets/310ccd8f-b9e2-40c1-b7e0-5c5f6ed1444b)

## Solution

Use an intermediate state for raw date which can be edited just like a text input for Firefox & Safari users, and is synced with the main start date when the input is valid.
It doesn't break for Chrome users because then the input date is always a valid date.

There's a bit of trickery with the date restored from the url, because the raw state is always initialized with the default date. That's why, when the raw date is valid, the value of the input is taken from the main date state instead.