### PR TITLE
maxed out caleandar grid at 4x3

### DIFF
--- a/src/components/Calendar.css
+++ b/src/components/Calendar.css
@@ -18,10 +18,18 @@
 	}
 }
 
+/* On small screens, minimum is one month per row  */
 @media (max-width: 530px) {
 	.calendar-container {
 		grid-template-columns: repeat(auto-fit, 100%);
 		width: 100%;
+	}
+}
+
+/* On large screens, max out the month grid at 4 x 3 columns/rows (12 months) */
+@media (min-width: 1200px) {
+	.calendar-container {
+		grid-template-columns: repeat(4, minmax(250px, 1fr));
 	}
 }
 


### PR DESCRIPTION
As you get onto a big screen, calendar rows can get wonky*,and look bad as a cluster of 5,5,2, or 6,6 .

 Tweaked the media layout to do a grid of 4 column 3 row view as it zooms out.  No 5/5/2, no /6/6 rows. 
 

[1] Example Wonky: 
 
Jan  | Feb |  March |  April |  May |  
June | July | Aug | Sept | Oct |
| Nov | Dec |