### PR TITLE
Add dark mode, read-only embed, and .ics export

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -15,7 +15,7 @@
 	height: 100vh;
 	width: 100%;
 	position: relative;
-	background-color: #f9f9f9;
+	background-color: var(--bg-primary);
 }
 
 /* Responsive layout */
@@ -37,8 +37,8 @@
 	z-index: 200;
 	padding: 8px 8px 4px;
 	border-radius: 50%;
-	background: #f9f9f9;
-	border: 1px solid #ccc;
+	background: var(--bg-primary);
+	border: 1px solid var(--border-primary);
 	cursor: pointer;
 	display: none;
 	transition: transform 0.3s ease;
@@ -58,4 +58,39 @@
 	max-width: 1200px;
 	margin: 0 auto;
 	padding: 20px;
+}
+
+/* Embed mode */
+.app-container.embed-mode {
+	flex-direction: column;
+	position: relative;
+}
+
+.app-container.embed-mode .calendar-container {
+	cursor: default;
+}
+
+.app-container.embed-mode .calendar-day {
+	cursor: default;
+}
+
+.embed-edit-badge {
+	position: fixed;
+	bottom: 8px;
+	right: 12px;
+	background-color: var(--accent);
+	color: white;
+	padding: 4px 12px;
+	border-radius: 4px;
+	font-size: 12px;
+	font-weight: 500;
+	text-decoration: none;
+	opacity: 0.85;
+	transition: opacity 0.2s;
+	z-index: 100;
+}
+
+.embed-edit-badge:hover {
+	opacity: 1;
+	color: white;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,10 +6,13 @@ import Calendar from "./components/Calendar";
 import ChevronIcon from "./components/icons/ChevronIcon";
 import HelpModal from "./components/HelpModal";
 import LicenseModal from "./components/LicenseModal";
+import EmbedModal from "./components/EmbedModal";
 
 function App() {
 	const [isSidebarHidden, setIsSidebarHidden] = useState(false);
 	const [showLicenseModal, setShowLicenseModal] = useState(false);
+	const [showEmbedModal, setShowEmbedModal] = useState(false);
+	const isEmbedMode = useStore((state) => state.isEmbedMode);
 	const getAppStateFromUrl = useStore((state) => state.getAppStateFromUrl);
 	const generateShareableUrl = useStore((state) => state.generateShareableUrl);
 	const showHelpModal = useStore((state) => state.showHelpModal);
@@ -23,6 +26,25 @@ function App() {
 	const showToday = useStore((state) => state.showToday);
 	const eventGroups = useStore((state) => state.eventGroups);
 	const firstDayOfWeek = useStore((state) => state.firstDayOfWeek);
+	const theme = useStore((state) => state.theme);
+
+	// Apply theme to document
+	useEffect(() => {
+		const applyTheme = (resolved: "light" | "dark") => {
+			document.documentElement.setAttribute("data-theme", resolved);
+		};
+
+		if (theme === "system") {
+			const mq = window.matchMedia("(prefers-color-scheme: dark)");
+			applyTheme(mq.matches ? "dark" : "light");
+			const handler = (e: MediaQueryListEvent) =>
+				applyTheme(e.matches ? "dark" : "light");
+			mq.addEventListener("change", handler);
+			return () => mq.removeEventListener("change", handler);
+		} else {
+			applyTheme(theme);
+		}
+	}, [theme]);
 
 	// Load state from URL on initial mount
 	useEffect(() => {
@@ -71,6 +93,23 @@ function App() {
 		}
 	};
 
+	if (isEmbedMode) {
+		const editUrl = window.location.href.replace(/[?&]embed=true/, "");
+		return (
+			<div className="app-container embed-mode">
+				<Calendar />
+				<a
+					className="embed-edit-badge"
+					href={editUrl}
+					target="_blank"
+					rel="noopener noreferrer"
+				>
+					Edit on PocketCal
+				</a>
+			</div>
+		);
+	}
+
 	return (
 		<div className={`app-container ${isSidebarHidden ? "sidebar-hidden" : ""}`}>
 			<button
@@ -79,13 +118,19 @@ function App() {
 				aria-label={isSidebarHidden ? "Show sidebar" : "Hide sidebar"}
 				aria-expanded={!isSidebarHidden}
 			>
-				<ChevronIcon color="black" />
+				<ChevronIcon color="var(--icon-color)" />
 			</button>
-			<Sidebar setShowLicenseModal={setShowLicenseModal} />
+			<Sidebar
+				setShowLicenseModal={setShowLicenseModal}
+				setShowEmbedModal={setShowEmbedModal}
+			/>
 			<Calendar />
 			{showHelpModal && <HelpModal onClose={() => setShowHelpModal(false)} />}
 			{showLicenseModal && (
 				<LicenseModal onClose={() => setShowLicenseModal(false)} />
+			)}
+			{showEmbedModal && (
+				<EmbedModal onClose={() => setShowEmbedModal(false)} />
 			)}
 		</div>
 	);

--- a/src/components/Calendar.css
+++ b/src/components/Calendar.css
@@ -5,7 +5,7 @@
 	grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
 	gap: 10px;
 	align-content: start;
-	background-color: #f9f9f9;
+	background-color: var(--bg-primary);
 	overflow-y: auto;
 	height: 100%;
 	box-sizing: border-box;
@@ -26,10 +26,10 @@
 }
 
 .calendar-month {
-	border: 1px solid #eee;
+	border: 1px solid var(--border-light);
 	padding: 8px;
 	border-radius: 6px;
-	background-color: white;
+	background-color: var(--bg-card);
 	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
 	min-width: 0;
 }
@@ -37,7 +37,7 @@
 .calendar-month h3 {
 	text-align: center;
 	margin: 0 0 8px 0;
-	color: #333;
+	color: var(--text-primary);
 	font-size: 0.9em;
 	font-weight: 600;
 }
@@ -46,7 +46,7 @@
 	display: grid;
 	grid-template-columns: repeat(7, 1fr);
 	gap: 1px;
-	background-color: #f5f5f5;
+	background-color: var(--bg-grid);
 	padding: 1px;
 	border-radius: 4px;
 	font-size: 0.8em;
@@ -61,12 +61,12 @@
 	font-weight: 600;
 	font-size: 0.7em;
 	padding: 2px;
-	background-color: #f8f9fa;
-	color: #666;
+	background-color: var(--bg-weekday);
+	color: var(--text-secondary);
 }
 
 .calendar-day {
-	background-color: #ffffff;
+	background-color: var(--bg-secondary);
 	border: 1px solid transparent;
 	min-height: 24px;
 	height: 24px;
@@ -81,7 +81,7 @@
 }
 
 .calendar-day:hover {
-	background-color: #f8f9fa;
+	background-color: var(--bg-weekday);
 }
 
 .calendar-day.empty {
@@ -94,9 +94,9 @@
 }
 
 .calendar-day.today .day-number {
-	color: #333;
+	color: var(--text-primary);
 	font-weight: bold;
-	border: 2px solid #eb4888;
+	border: 2px solid var(--today-border);
 	border-radius: 50%;
 	box-sizing: border-box;
 	width: 20px;
@@ -108,20 +108,20 @@
 }
 
 .calendar-day:has(.range-indicator).today .day-number {
-	color: #333;
-	background-color: #fff;
+	color: var(--today-text-on-range);
+	background-color: var(--today-bg-on-range);
 	border-color: transparent;
 	text-shadow: none;
 }
 
 .calendar-day.dragging {
-	background-color: #e3f2fd;
-	border: 1px dashed #2196f3;
+	background-color: var(--drag-bg);
+	border: 1px dashed var(--drag-border);
 }
 
 .day-number {
 	font-size: 0.9em;
-	color: #333;
+	color: var(--text-primary);
 	width: 20px;
 	height: 20px;
 	display: flex;
@@ -134,9 +134,9 @@
 
 /* When the calendar day has range indicators, make the number white and bold */
 .calendar-day:has(.range-indicator) .day-number {
-	color: white;
+	color: var(--day-text-on-range);
 	font-weight: bold;
-	text-shadow: 0 1px 2px rgba(0, 0, 0, 0.7);
+	text-shadow: 0 1px 2px var(--day-shadow-on-range);
 }
 
 .range-indicators {
@@ -159,7 +159,7 @@
 }
 
 .calendar-container:focus {
-	outline: 2px solid rgba(138, 53, 222, 0.5);
+	outline: 2px solid var(--accent-outline);
 	outline-offset: 2px;
 }
 
@@ -168,7 +168,7 @@
 }
 
 .calendar-day.focused {
-	outline: 2px solid rgba(138, 53, 222, 0.8);
+	outline: 2px solid var(--accent-outline-strong);
 	outline-offset: -2px;
 	z-index: 3;
 }

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -34,6 +34,7 @@ const Calendar: React.FC = () => {
 		addDateRange,
 		deleteDateRange,
 		firstDayOfWeek,
+		isEmbedMode,
 	} = useStore();
 
 	const calendarDates = getCalendarDates(startDate);
@@ -130,7 +131,7 @@ const Calendar: React.FC = () => {
 	};
 
 	const handleDateSelection = (date: Date) => {
-		if (!selectedGroupId) return;
+		if (isEmbedMode || !selectedGroupId) return;
 
 		const selectedGroup = eventGroups.find(
 			(group) => group.id === selectedGroupId
@@ -173,7 +174,7 @@ const Calendar: React.FC = () => {
 	};
 
 	const handleMouseDown = (date: Date) => {
-		if (!selectedGroupId) return;
+		if (isEmbedMode || !selectedGroupId) return;
 		setFocusedDate(date);
 
 		const selectedGroup = eventGroups.find(

--- a/src/components/EmbedModal.tsx
+++ b/src/components/EmbedModal.tsx
@@ -1,7 +1,9 @@
 import React, { useState } from "react";
 import XIcon from "./icons/XIcon";
 import CopyIcon from "./icons/CopyIcon";
+import DownloadIcon from "./icons/DownloadIcon";
 import { useStore } from "../store";
+import { downloadICS } from "../ics";
 import "./Modal.css";
 
 interface EmbedModalProps {
@@ -10,19 +12,29 @@ interface EmbedModalProps {
 
 const EmbedModal: React.FC<EmbedModalProps> = ({ onClose }) => {
 	const generateShareableUrl = useStore((state) => state.generateShareableUrl);
-	const [copied, setCopied] = useState(false);
+	const eventGroups = useStore((state) => state.eventGroups);
+	const [copiedSnippet, setCopiedSnippet] = useState<string | null>(null);
+	const [shareButtonFormat, setShareButtonFormat] = useState<"markdown" | "html">("markdown");
 
 	const shareableUrl = generateShareableUrl();
+	const shareButtonUrl = `${window.location.origin}/share-button.svg`;
 	const embedUrl = shareableUrl.includes("?")
 		? `${shareableUrl}&embed=true`
 		: `${shareableUrl.split("#")[0]}?embed=true#${shareableUrl.split("#")[1] || ""}`;
 
 	const embedCode = `<iframe src="${embedUrl}" width="100%" height="600" style="border: none; border-radius: 8px;" title="PocketCal Calendar"></iframe>`;
+	const markdownButtonCode = `[![Open in PocketCal](${shareButtonUrl})](${shareableUrl})`;
+	const htmlButtonCode = `<a href="${shareableUrl}"><img src="${shareButtonUrl}" alt="Open in PocketCal" /></a>`;
+	const shareButtonCode =
+		shareButtonFormat === "markdown" ? markdownButtonCode : htmlButtonCode;
+	const shareButtonSnippetName = `${shareButtonFormat}-button`;
+	const shareButtonCopyText =
+		shareButtonFormat === "markdown" ? "Copy Markdown" : "Copy HTML";
 
-	const handleCopy = () => {
-		navigator.clipboard.writeText(embedCode);
-		setCopied(true);
-		setTimeout(() => setCopied(false), 2000);
+	const handleCopy = (snippetName: string, text: string) => {
+		navigator.clipboard.writeText(text);
+		setCopiedSnippet(snippetName);
+		setTimeout(() => setCopiedSnippet(null), 2000);
 	};
 
 	return (
@@ -31,22 +43,72 @@ const EmbedModal: React.FC<EmbedModalProps> = ({ onClose }) => {
 				<button
 					className="modal-close"
 					onClick={onClose}
-					aria-label="Close embed modal"
+					aria-label="Close share modal"
 				>
 					<XIcon color="var(--icon-color)" />
 				</button>
-				<h2>Embed Calendar</h2>
-				<p>
-					Copy the code below to embed a read-only version of your calendar on
-					any website.
-				</p>
-				<pre className="license-key-display" style={{ whiteSpace: "pre-wrap", wordBreak: "break-all" }}>
-					{embedCode}
-				</pre>
-				<button onClick={handleCopy} className="btn" style={{ marginTop: "12px", display: "flex", alignItems: "center", gap: "6px" }}>
-					<CopyIcon width={16} height={16} color="white" />
-					{copied ? "Copied!" : "Copy Embed Code"}
-				</button>
+				<h2>Share calendar</h2>
+				<section className="share-section">
+					<h3>Export .ics</h3>
+					<div className="share-row">
+						<p>Download this calendar as an .ics file.</p>
+						<button onClick={() => downloadICS(eventGroups)} className="btn icon-btn">
+							<DownloadIcon width={16} height={16} color="white" />
+							Export .ics
+						</button>
+					</div>
+				</section>
+				<section className="share-section">
+					<h3>Embed calendar as HTML</h3>
+					<p>
+						Copy the code below to embed a read-only version of your calendar on
+						any website.
+					</p>
+					<pre className="copy-text-embed">
+						{embedCode}
+					</pre>
+					<div className="share-actions">
+						<button onClick={() => handleCopy("embed", embedCode)} className="btn icon-btn">
+							<CopyIcon width={16} height={16} color="white" />
+							{copiedSnippet === "embed" ? "Copied!" : "Copy Embed Code"}
+						</button>
+					</div>
+				</section>
+				<section className="share-section">
+					<h3>Share button</h3>
+					<p>
+						Copy a Markdown or HTML button that links to this calendar.
+					</p>
+					<div className="share-tabs" role="tablist" aria-label="Share button format">
+						<button
+							type="button"
+							role="tab"
+							aria-selected={shareButtonFormat === "markdown"}
+							className={shareButtonFormat === "markdown" ? "active" : ""}
+							onClick={() => setShareButtonFormat("markdown")}
+						>
+							Markdown
+						</button>
+						<button
+							type="button"
+							role="tab"
+							aria-selected={shareButtonFormat === "html"}
+							className={shareButtonFormat === "html" ? "active" : ""}
+							onClick={() => setShareButtonFormat("html")}
+						>
+							HTML
+						</button>
+					</div>
+					<pre className="copy-text-embed">
+						{shareButtonCode}
+					</pre>
+					<div className="share-actions">
+						<button onClick={() => handleCopy(shareButtonSnippetName, shareButtonCode)} className="btn icon-btn">
+							<CopyIcon width={16} height={16} color="white" />
+							{copiedSnippet === shareButtonSnippetName ? "Copied!" : shareButtonCopyText}
+						</button>
+					</div>
+				</section>
 			</div>
 		</div>
 	);

--- a/src/components/EmbedModal.tsx
+++ b/src/components/EmbedModal.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from "react";
+import XIcon from "./icons/XIcon";
+import CopyIcon from "./icons/CopyIcon";
+import { useStore } from "../store";
+import "./Modal.css";
+
+interface EmbedModalProps {
+	onClose: () => void;
+}
+
+const EmbedModal: React.FC<EmbedModalProps> = ({ onClose }) => {
+	const generateShareableUrl = useStore((state) => state.generateShareableUrl);
+	const [copied, setCopied] = useState(false);
+
+	const shareableUrl = generateShareableUrl();
+	const embedUrl = shareableUrl.includes("?")
+		? `${shareableUrl}&embed=true`
+		: `${shareableUrl.split("#")[0]}?embed=true#${shareableUrl.split("#")[1] || ""}`;
+
+	const embedCode = `<iframe src="${embedUrl}" width="100%" height="600" style="border: none; border-radius: 8px;" title="PocketCal Calendar"></iframe>`;
+
+	const handleCopy = () => {
+		navigator.clipboard.writeText(embedCode);
+		setCopied(true);
+		setTimeout(() => setCopied(false), 2000);
+	};
+
+	return (
+		<div className="modal-overlay" onClick={onClose}>
+			<div className="modal-content" onClick={(e) => e.stopPropagation()}>
+				<button
+					className="modal-close"
+					onClick={onClose}
+					aria-label="Close embed modal"
+				>
+					<XIcon color="var(--icon-color)" />
+				</button>
+				<h2>Embed Calendar</h2>
+				<p>
+					Copy the code below to embed a read-only version of your calendar on
+					any website.
+				</p>
+				<pre className="license-key-display" style={{ whiteSpace: "pre-wrap", wordBreak: "break-all" }}>
+					{embedCode}
+				</pre>
+				<button onClick={handleCopy} className="btn" style={{ marginTop: "12px", display: "flex", alignItems: "center", gap: "6px" }}>
+					<CopyIcon width={16} height={16} color="white" />
+					{copied ? "Copied!" : "Copy Embed Code"}
+				</button>
+			</div>
+		</div>
+	);
+};
+
+export default EmbedModal;

--- a/src/components/HelpModal.tsx
+++ b/src/components/HelpModal.tsx
@@ -16,7 +16,7 @@ const HelpModal: React.FC<HelpModalProps> = ({ onClose }) => {
 					onClick={onClose}
 					aria-label="Close instructions"
 				>
-					<XIcon color="#000" />
+					<XIcon color="var(--icon-color)" />
 				</button>
 				<h2>
 					Pocket<span>Cal</span> Instructions

--- a/src/components/LicenseModal.tsx
+++ b/src/components/LicenseModal.tsx
@@ -76,7 +76,7 @@ const LicenseModal: React.FC<LicenseModalProps> = ({ onClose }) => {
 					onClick={onClose}
 					aria-label="Close license modal"
 				>
-					<XIcon color="#000" />
+					<XIcon color="var(--icon-color)" />
 				</button>
 				<h2>
 					Pocket<span className="logo-cal">Cal</span>{" "}
@@ -87,7 +87,7 @@ const LicenseModal: React.FC<LicenseModalProps> = ({ onClose }) => {
 				{isProUser ? (
 					<div className="license-status">
 						<p className="license-active">
-							<CalIcon color="#000" />
+							<CalIcon color="var(--icon-color)" />
 							<strong>Pro license active!</strong>
 						</p>
 

--- a/src/components/LicenseModal.tsx
+++ b/src/components/LicenseModal.tsx
@@ -91,7 +91,7 @@ const LicenseModal: React.FC<LicenseModalProps> = ({ onClose }) => {
 							<strong>Pro license active!</strong>
 						</p>
 
-						<pre className="license-key-display">
+						<pre className="copy-text-embed">
 							{licenseKey ||
 								"No license key! If you see this, something is wrong."}
 						</pre>

--- a/src/components/Modal.css
+++ b/src/components/Modal.css
@@ -12,7 +12,8 @@
 }
 
 .modal-content {
-	background: white;
+	background: var(--bg-secondary);
+	color: var(--text-primary);
 	border-radius: 8px;
 	padding: 24px;
 	max-width: 500px;
@@ -22,7 +23,7 @@
 }
 
 .modal-content a {
-	color: #8a35de;
+	color: var(--accent);
 }
 
 .modal-content h2 {
@@ -62,7 +63,7 @@
 }
 
 button.btn {
-	background-color: #8a35de;
+	background-color: var(--accent);
 	color: white;
 	border: none;
 	border-radius: 4px;
@@ -71,20 +72,22 @@ button.btn {
 }
 
 button.btn[disabled] {
-	background-color: #8a35de99;
+	opacity: 0.6;
 	cursor: not-allowed;
 }
 
 input[type="text"] {
 	padding: 8px;
-	border: 1px solid #ccc;
+	border: 1px solid var(--border-primary);
 	border-radius: 4px;
 	margin-top: 8px;
 	width: 100%;
 	box-sizing: border-box;
+	background-color: var(--bg-input);
+	color: var(--text-input);
 }
 input[type="text"]:focus {
-	border-color: #8a35de;
+	border-color: var(--accent);
 	outline: none;
 }
 
@@ -103,7 +106,7 @@ input[type="text"]:focus {
 }
 
 p.pro-description span {
-	color: #8a35de;
+	color: var(--accent);
 	font-weight: bold;
 }
 
@@ -114,11 +117,12 @@ p.license-active {
 }
 
 pre.license-key-display {
-	background-color: #f5f5f5;
-	border: 1px solid #ccc;
+	background-color: var(--bg-code);
+	border: 1px solid var(--border-primary);
 	border-radius: 4px;
 	padding: 8px;
 	overflow-x: auto;
 	font-family: monospace;
 	margin-top: 8px;
+	color: var(--text-primary);
 }

--- a/src/components/Modal.css
+++ b/src/components/Modal.css
@@ -62,6 +62,68 @@
 	margin-bottom: 6px;
 }
 
+.share-section {
+	margin-top: 20px;
+}
+
+.share-section h3 {
+	margin: 0 0 8px;
+}
+
+.share-section p {
+	margin: 0;
+}
+
+.share-tabs {
+	display: inline-flex;
+	margin-top: 12px;
+}
+
+.share-tabs button {
+	background-color: var(--bg-tertiary);
+	border: none;
+	color: var(--text-primary);
+	cursor: pointer;
+	padding: 6px 12px;
+}
+
+.share-tabs button:first-child {
+	border-radius: 4px 0 0 4px;
+}
+
+.share-tabs button:last-child {
+	border-radius: 0 4px 4px 0;
+}
+
+.share-tabs button + button {
+	margin-left: 1px;
+}
+
+.share-tabs button.active {
+	background-color: var(--accent);
+	color: white;
+}
+
+.share-row {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 16px;
+}
+
+.share-actions {
+	display: flex;
+	justify-content: flex-end;
+	margin-top: 12px;
+}
+
+button.icon-btn {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	white-space: nowrap;
+}
+
 button.btn {
 	background-color: var(--accent);
 	color: white;
@@ -116,7 +178,7 @@ p.license-active {
 	gap: 8px;
 }
 
-pre.license-key-display {
+pre.copy-text-embed {
 	background-color: var(--bg-code);
 	border: 1px solid var(--border-primary);
 	border-radius: 4px;
@@ -125,4 +187,5 @@ pre.license-key-display {
 	font-family: monospace;
 	margin-top: 8px;
 	color: var(--text-primary);
+	white-space: nowrap;
 }

--- a/src/components/Sidebar.css
+++ b/src/components/Sidebar.css
@@ -4,8 +4,8 @@
 	display: flex;
 	flex-direction: column;
 	gap: 16px;
-	background-color: #f9f9f9;
-	color: #333;
+	background-color: var(--bg-primary);
+	color: var(--text-primary);
 	overflow-y: auto;
 	overflow-x: hidden;
 	transition: max-height 0.3s ease;
@@ -27,7 +27,7 @@
 
 .sidebar h1,
 .sidebar h3 {
-	border-bottom: 1px solid #eee;
+	border-bottom: 1px solid var(--border-light);
 	padding-bottom: 5px;
 	font-weight: 500;
 }
@@ -37,7 +37,7 @@ h2 {
 }
 
 .logo-cal {
-	color: rgb(138, 53, 222);
+	color: var(--accent);
 	font-weight: 700;
 }
 
@@ -52,7 +52,7 @@ h2 {
 		height: auto;
 		max-height: 50vh;
 		border-right: none;
-		border-bottom: 1px solid #ccc;
+		border-bottom: 1px solid var(--border-primary);
 		position: relative;
 		z-index: 10;
 	}
@@ -81,10 +81,10 @@ h2 {
 	display: flex;
 	align-items: center;
 	padding: 8px;
-	border: 1px solid #ddd;
+	border: 1px solid var(--border-secondary);
 	border-radius: 4px;
 	cursor: pointer;
-	background-color: #fff;
+	background-color: var(--bg-secondary);
 	gap: 8px;
 	min-height: 30px;
 }
@@ -110,10 +110,10 @@ h2 {
 }
 
 .event-group-item.selected {
-	background: linear-gradient(90deg, #ffffff, rgba(138, 53, 222, 0.05));
+	background: linear-gradient(90deg, var(--bg-secondary), var(--accent-soft));
 	background-size: 120% 120%;
 	animation: gradient-animation 2s ease infinite;
-	box-shadow: 0 0 0 2px rgba(138, 53, 222, 0.25);
+	box-shadow: 0 0 0 2px var(--accent-border);
 }
 
 @keyframes gradient-animation {
@@ -129,7 +129,7 @@ h2 {
 }
 
 .event-group-item:hover {
-	background-color: #f0f0f0;
+	background-color: var(--bg-hover);
 }
 
 .color-indicator {
@@ -138,7 +138,7 @@ h2 {
 	height: 15px;
 	border-radius: 50%;
 	margin-right: 8px;
-	border: 1px solid #ccc;
+	border: 1px solid var(--border-primary);
 	flex-shrink: 0;
 }
 
@@ -164,32 +164,32 @@ h2 {
 	width: 100%;
 	box-sizing: border-box;
 	background: transparent;
-	color: #333;
+	color: var(--text-primary);
 	font-size: 0.85em;
 }
 
 .add-group-button:hover {
-	background-color: #f0f0f0;
+	background-color: var(--bg-hover);
 	border-color: transparent;
 	transition: background-color 0.3s ease;
 }
 
 .add-group-button:disabled {
-	background-color: #f0f0f0;
-	color: #ccc;
+	background-color: var(--bg-hover);
+	color: var(--border-primary);
 	cursor: not-allowed;
 }
 
 input {
-	background-color: #fff;
-	border: 1px solid #ccc;
+	background-color: var(--bg-input);
+	border: 1px solid var(--border-primary);
 	border-radius: 4px;
-	color: #000;
+	color: var(--text-input);
 	font-size: 1em;
 }
 
 input[type="month"]::-webkit-calendar-picker-indicator {
-	filter: brightness(0);
+	filter: var(--calendar-picker-filter);
 }
 
 input.group-name-input {
@@ -206,7 +206,7 @@ input.group-name-input {
 		height: auto;
 		max-height: 50vh;
 		border-right: none;
-		border-bottom: 1px solid #ccc;
+		border-bottom: 1px solid var(--border-primary);
 		position: relative;
 		z-index: 10;
 	}
@@ -244,8 +244,8 @@ input.group-name-input {
 .footer-button {
 	flex: 1;
 	padding: 8px 12px;
-	background-color: #f0f0f0;
-	border: 1px solid #ddd;
+	background-color: var(--bg-tertiary);
+	border: 1px solid var(--border-secondary);
 	border-radius: 4px;
 	cursor: pointer;
 	font-size: 14px;
@@ -254,12 +254,22 @@ input.group-name-input {
 	justify-content: center;
 	gap: 4px;
 	transition: background-color 0.2s;
+	color: var(--text-primary);
 }
 
 .footer-button:hover {
-	background-color: #e0e0e0;
+	background-color: var(--bg-active);
 }
 
 .footer-button:active {
-	background-color: #d0d0d0;
+	background-color: var(--bg-pressed);
+}
+
+select {
+	background-color: var(--bg-input);
+	border: 1px solid var(--border-primary);
+	border-radius: 4px;
+	color: var(--text-input);
+	font-size: 1em;
+	padding: 4px;
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -10,8 +10,8 @@ import PlusIcon from "./icons/PlusIcon";
 import SettingsIcon from "./icons/SettingsIcon";
 import HelpIcon from "./icons/HelpIcon";
 import CopyIcon from "./icons/CopyIcon";
+import ShareIcon from "./icons/ShareIcon";
 
-import { downloadICS } from "../ics";
 import "./Sidebar.css";
 
 function Sidebar({
@@ -122,15 +122,8 @@ function Sidebar({
 				</button>
 			</div>
 		);
-		let helpAndCopyButtons = (
+		let copyAndHelpButtons = (
 			<div className="sidebar-footer-buttons">
-				<button
-					className="footer-button"
-					onClick={() => setShowHelpModal(true)}
-					aria-label="Show instructions"
-				>
-					<HelpIcon color="var(--icon-color)" /> Help
-				</button>
 				<button
 					className="footer-button"
 					onClick={handleCopyUrl}
@@ -138,30 +131,30 @@ function Sidebar({
 				>
 					<CopyIcon color="var(--icon-color)" /> Copy URL
 				</button>
+				<button
+					className="footer-button"
+					onClick={() => setShowHelpModal(true)}
+					aria-label="Show instructions"
+				>
+					<HelpIcon color="var(--icon-color)" /> Help
+				</button>
 			</div>
 		);
-		let exportAndEmbedButtons = (
+		let shareButton = (
 			<div className="sidebar-footer-buttons">
 				<button
 					className="footer-button"
-					onClick={() => downloadICS(eventGroups)}
-					aria-label="Export calendar to .ics file"
-				>
-					Export .ics
-				</button>
-				<button
-					className="footer-button"
 					onClick={() => setShowEmbedModal(true)}
-					aria-label="Get embed code"
+					aria-label="Share calendar"
 				>
-					Embed
+					<ShareIcon color="var(--icon-color)" /> Share
 				</button>
 			</div>
 		);
 
 		return isProUser
-			? [helpAndCopyButtons, exportAndEmbedButtons, proButton]
-			: [proButton, helpAndCopyButtons, exportAndEmbedButtons];
+			? [copyAndHelpButtons, shareButton, proButton]
+			: [proButton, copyAndHelpButtons, shareButton];
 	};
 
 	return (

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { useStore, EventGroup, getMaxGroups } from "../store";
+import { useStore, EventGroup, getMaxGroups, Theme } from "../store";
 import { format } from "date-fns";
 import CalIcon from "./icons/CalIcon";
 import PencilIcon from "./icons/PencilIcon";
@@ -11,12 +11,15 @@ import SettingsIcon from "./icons/SettingsIcon";
 import HelpIcon from "./icons/HelpIcon";
 import CopyIcon from "./icons/CopyIcon";
 
+import { downloadICS } from "../ics";
 import "./Sidebar.css";
 
 function Sidebar({
 	setShowLicenseModal,
+	setShowEmbedModal,
 }: {
 	setShowLicenseModal: (show: boolean) => void;
+	setShowEmbedModal: (show: boolean) => void;
 }) {
 	const {
 		startDate,
@@ -35,6 +38,8 @@ function Sidebar({
 		isProUser,
 		firstDayOfWeek,
 		setFirstDayOfWeek,
+		theme,
+		setTheme,
 	} = useStore();
 	const maxGroups = getMaxGroups(isProUser);
 	const [newEventName, setNewEventName] = useState("");
@@ -124,21 +129,39 @@ function Sidebar({
 					onClick={() => setShowHelpModal(true)}
 					aria-label="Show instructions"
 				>
-					<HelpIcon color="#000" /> Help
+					<HelpIcon color="var(--icon-color)" /> Help
 				</button>
 				<button
 					className="footer-button"
 					onClick={handleCopyUrl}
 					aria-label="Copy URL to clipboard"
 				>
-					<CopyIcon color="#000" /> Copy URL
+					<CopyIcon color="var(--icon-color)" /> Copy URL
+				</button>
+			</div>
+		);
+		let exportAndEmbedButtons = (
+			<div className="sidebar-footer-buttons">
+				<button
+					className="footer-button"
+					onClick={() => downloadICS(eventGroups)}
+					aria-label="Export calendar to .ics file"
+				>
+					Export .ics
+				</button>
+				<button
+					className="footer-button"
+					onClick={() => setShowEmbedModal(true)}
+					aria-label="Get embed code"
+				>
+					Embed
 				</button>
 			</div>
 		);
 
 		return isProUser
-			? [helpAndCopyButtons, proButton]
-			: [proButton, helpAndCopyButtons];
+			? [helpAndCopyButtons, exportAndEmbedButtons, proButton]
+			: [proButton, helpAndCopyButtons, exportAndEmbedButtons];
 	};
 
 	return (
@@ -199,7 +222,7 @@ function Sidebar({
 										className="save-button"
 										aria-label="Save group name"
 									>
-										<SaveIcon color="#000" />
+										<SaveIcon color="var(--icon-color)" />
 									</button>
 									<button
 										onClick={(e) => {
@@ -209,7 +232,7 @@ function Sidebar({
 										className="cancel-button"
 										aria-label="Cancel editing"
 									>
-										<XIcon color="#000" />
+										<XIcon color="var(--icon-color)" />
 									</button>
 								</div>
 							</>
@@ -226,7 +249,7 @@ function Sidebar({
 										className="edit-button"
 										aria-label={`Edit ${group.name}`}
 									>
-										<PencilIcon color="#000" />
+										<PencilIcon color="var(--icon-color)" />
 									</button>
 									<button
 										onClick={(e) => {
@@ -237,7 +260,7 @@ function Sidebar({
 										className="delete-button"
 										aria-label={`Delete ${group.name}`}
 									>
-										<TrashIcon color="#000" />
+										<TrashIcon color="var(--icon-color)" />
 									</button>
 								</div>
 							</>
@@ -297,6 +320,18 @@ function Sidebar({
 						checked={showToday}
 						onChange={(e) => setShowToday(e.target.checked)}
 					/>
+				</div>
+				<div className="setting-item">
+					<label htmlFor="theme">Theme:</label>
+					<select
+						id="theme"
+						value={theme}
+						onChange={(e) => setTheme(e.target.value as Theme)}
+					>
+						<option value="system">System</option>
+						<option value="light">Light</option>
+						<option value="dark">Dark</option>
+					</select>
 				</div>
 			</>
 

--- a/src/components/icons/DownloadIcon.tsx
+++ b/src/components/icons/DownloadIcon.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { IconProps } from "./SharedProps";
+
+const DownloadIcon: React.FC<IconProps> = ({
+	width = 24,
+	height = 24,
+	color = "currentColor",
+}) => {
+	return (
+		<svg
+			width={width}
+			height={height}
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke={color}
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			xmlns="http://www.w3.org/2000/svg"
+			aria-hidden="true"
+		>
+			<path d="M7.8 11.5l2.1 2.3 2.1 2.3V3m0 13.1l2.1-2.3 2.1-2.3m4.8 3.6V19a2 2 0 01-2 2H5a2.006 2.006 0 01-2-2v-3.9"></path>
+		</svg>
+	);
+};
+
+export default DownloadIcon;

--- a/src/components/icons/ShareIcon.tsx
+++ b/src/components/icons/ShareIcon.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { IconProps } from "./SharedProps";
+
+const ShareIcon: React.FC<IconProps> = ({
+	width = 24,
+	height = 24,
+	color = "currentColor",
+}) => {
+	return (
+		<svg
+			width={width}
+			height={height}
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke={color}
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			xmlns="http://www.w3.org/2000/svg"
+			aria-hidden="true"
+		>
+			<path d="M21 5.841a2.8 2.8 0 11-2.8-2.8 2.8 2.8 0 012.8 2.8zM18.2 15.4a2.8 2.8 0 102.8 2.8 2.8 2.8 0 00-2.8-2.8zM5.8 9.22a2.8 2.8 0 102.8 2.8 2.8 2.8 0 00-2.8-2.8zm9.6-2.2l-6.8 3.551m7 6.6l-7-3.8"></path>
+		</svg>
+	);
+};
+
+export default ShareIcon;

--- a/src/ics.ts
+++ b/src/ics.ts
@@ -1,0 +1,61 @@
+import { EventGroup } from "./store";
+import { parseISO, addDays, format } from "date-fns";
+
+function foldLine(line: string): string {
+	const parts: string[] = [];
+	let remaining = line;
+	while (remaining.length > 75) {
+		parts.push(remaining.slice(0, 75));
+		remaining = " " + remaining.slice(75);
+	}
+	parts.push(remaining);
+	return parts.join("\r\n");
+}
+
+export function generateICS(eventGroups: EventGroup[]): string {
+	const now = new Date();
+	const timestamp = format(now, "yyyyMMdd'T'HHmmss'Z'");
+
+	const lines: string[] = [
+		"BEGIN:VCALENDAR",
+		"VERSION:2.0",
+		"PRODID:-//PocketCal//pocketcal.com//EN",
+		"CALSCALE:GREGORIAN",
+		"METHOD:PUBLISH",
+	];
+
+	for (const group of eventGroups) {
+		for (const range of group.ranges) {
+			const startDate = parseISO(range.start);
+			// ICS DTEND for all-day events is exclusive, so add 1 day
+			const endDate = addDays(parseISO(range.end), 1);
+
+			const dtStart = format(startDate, "yyyyMMdd");
+			const dtEnd = format(endDate, "yyyyMMdd");
+
+			lines.push("BEGIN:VEVENT");
+			lines.push(`DTSTART;VALUE=DATE:${dtStart}`);
+			lines.push(`DTEND;VALUE=DATE:${dtEnd}`);
+			lines.push(foldLine(`SUMMARY:${group.name}`));
+			lines.push(`DTSTAMP:${timestamp}`);
+			lines.push(`UID:${dtStart}-${dtEnd}-${group.id}@pocketcal.com`);
+			lines.push("END:VEVENT");
+		}
+	}
+
+	lines.push("END:VCALENDAR");
+	return lines.join("\r\n");
+}
+
+export function downloadICS(eventGroups: EventGroup[]) {
+	const icsContent = generateICS(eventGroups);
+	const blob = new Blob([icsContent], { type: "text/calendar;charset=utf-8" });
+	const url = URL.createObjectURL(blob);
+	const a = document.createElement("a");
+	a.href = url;
+	a.download = "pocketcal.ics";
+	document.body.appendChild(a);
+	a.click();
+	document.body.removeChild(a);
+	URL.revokeObjectURL(url);
+}

--- a/src/index.css
+++ b/src/index.css
@@ -7,15 +7,108 @@
 	text-rendering: optimizeLegibility;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
+
+	/* Light theme (default) */
+	--bg-primary: #f9f9f9;
+	--bg-secondary: #ffffff;
+	--bg-tertiary: #f0f0f0;
+	--bg-hover: #f0f0f0;
+	--bg-active: #e0e0e0;
+	--bg-pressed: #d0d0d0;
+	--bg-card: white;
+	--bg-grid: #f5f5f5;
+	--bg-weekday: #f8f9fa;
+	--bg-input: #fff;
+	--bg-code: #f5f5f5;
+
+	--text-primary: #333;
+	--text-secondary: #666;
+	--text-heading: #213547;
+	--text-input: #000;
+
+	--border-primary: #ccc;
+	--border-secondary: #ddd;
+	--border-light: #eee;
+
+	--accent: #8a35de;
+	--accent-soft: rgba(138, 53, 222, 0.05);
+	--accent-border: rgba(138, 53, 222, 0.25);
+	--accent-focus: rgba(138, 53, 222, 0.3);
+	--accent-outline: rgba(138, 53, 222, 0.5);
+	--accent-outline-strong: rgba(138, 53, 222, 0.8);
+
+	--drag-bg: #e3f2fd;
+	--drag-border: #2196f3;
+
+	--today-border: #eb4888;
+	--today-text-on-range: #333;
+	--today-bg-on-range: #fff;
+
+	--day-text-on-range: white;
+	--day-shadow-on-range: rgba(0, 0, 0, 0.7);
+
+	--link-color: #646cff;
+	--link-hover: #747bff;
+
+	--icon-color: #000;
+
+	--calendar-picker-filter: brightness(0);
+}
+
+[data-theme="dark"] {
+	--bg-primary: #1a1a2e;
+	--bg-secondary: #16213e;
+	--bg-tertiary: #252545;
+	--bg-hover: #2a2a4a;
+	--bg-active: #353560;
+	--bg-pressed: #404070;
+	--bg-card: #1e1e3a;
+	--bg-grid: #222244;
+	--bg-weekday: #252548;
+	--bg-input: #252545;
+	--bg-code: #252545;
+
+	--text-primary: #e0e0e0;
+	--text-secondary: #a0a0b0;
+	--text-heading: #e8e8f0;
+	--text-input: #e0e0e0;
+
+	--border-primary: #404060;
+	--border-secondary: #353555;
+	--border-light: #2a2a4a;
+
+	--accent: #a855f7;
+	--accent-soft: rgba(168, 85, 247, 0.1);
+	--accent-border: rgba(168, 85, 247, 0.35);
+	--accent-focus: rgba(168, 85, 247, 0.4);
+	--accent-outline: rgba(168, 85, 247, 0.5);
+	--accent-outline-strong: rgba(168, 85, 247, 0.8);
+
+	--drag-bg: rgba(33, 150, 243, 0.15);
+	--drag-border: #64b5f6;
+
+	--today-border: #f472b6;
+	--today-text-on-range: #e0e0e0;
+	--today-bg-on-range: #1e1e3a;
+
+	--day-text-on-range: white;
+	--day-shadow-on-range: rgba(0, 0, 0, 0.9);
+
+	--link-color: #818cf8;
+	--link-hover: #a5b4fc;
+
+	--icon-color: #e0e0e0;
+
+	--calendar-picker-filter: brightness(0) invert(1);
 }
 
 a {
 	font-weight: 500;
-	color: #646cff;
+	color: var(--link-color);
 	text-decoration: inherit;
 }
 a:hover {
-	color: #535bf2;
+	color: var(--link-hover);
 }
 
 body {
@@ -25,6 +118,8 @@ body {
 		sans-serif;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
+	background-color: var(--bg-primary);
+	color: var(--text-heading);
 }
 
 button {
@@ -34,25 +129,12 @@ button {
 	font-size: 1em;
 	font-weight: 500;
 	font-family: inherit;
-	background-color: #1a1a1a;
+	background-color: var(--bg-primary);
 	cursor: pointer;
 	transition: border-color 0.25s;
 }
 button:focus,
 button:focus-visible {
-	outline: 4px auto rgba(138, 53, 222, 0.3);
+	outline: 4px auto var(--accent-focus);
 	outline-offset: 2px;
-}
-
-@media (prefers-color-scheme: light) {
-	:root {
-		color: #213547;
-		background-color: #ffffff;
-	}
-	a:hover {
-		color: #747bff;
-	}
-	button {
-		background-color: #f9f9f9;
-	}
 }

--- a/src/index.css
+++ b/src/index.css
@@ -57,7 +57,7 @@
 
 [data-theme="dark"] {
 	--bg-primary: #1a1a2e;
-	--bg-secondary: #16213e;
+	--bg-secondary: #1e1e3a;
 	--bg-tertiary: #252545;
 	--bg-hover: #2a2a4a;
 	--bg-active: #353560;

--- a/src/store.ts
+++ b/src/store.ts
@@ -43,6 +43,8 @@ export interface EventGroup {
 	ranges: DateRange[];
 }
 
+export type Theme = "light" | "dark" | "system";
+
 interface AppState {
 	startDate: Date;
 	includeWeekends: boolean;
@@ -52,7 +54,10 @@ interface AppState {
 	showHelpModal: boolean;
 	licenseKey: string | null;
 	isProUser: boolean;
+	isEmbedMode: boolean;
 	firstDayOfWeek: 0 | 1; // 0 = sunday, 1 = monday
+	theme: Theme;
+	setTheme: (theme: Theme) => void;
 	setFirstDayOfWeek: (day: 0 | 1) => void;
 	setStartDate: (date: Date) => void;
 	setIncludeWeekends: (include: boolean) => void;
@@ -103,6 +108,12 @@ export const useStore = create<AppState>((set, get) => ({
 	showHelpModal: false,
 	licenseKey: localStorage.getItem("pocketcal_license") || null,
 	isProUser: false,
+	isEmbedMode: new URLSearchParams(window.location.search).get("embed") === "true",
+	theme: (localStorage.getItem("pocketcal_theme") as Theme) || "system",
+	setTheme: (theme: Theme) => {
+		localStorage.setItem("pocketcal_theme", theme);
+		set({ theme });
+	},
 	setFirstDayOfWeek: (day: 0 | 1) => set({ firstDayOfWeek: day }),
 
 	setStartDate: (date) => set({ startDate: startOfMonth(date) }),
@@ -386,7 +397,7 @@ export const useStore = create<AppState>((set, get) => ({
 		const compressed = LZString.compressToEncodedURIComponent(
 			JSON.stringify(compressedState)
 		);
-		return `${window.location.origin}${window.location.pathname}#${compressed}`;
+		return `${window.location.origin}${window.location.pathname}${window.location.search}#${compressed}`;
 	},
 }));
 


### PR DESCRIPTION
Coded with all the vibes. I feel confident and the CSS'ing. The ICS download component looks alright to me and I tested the download. The embed modal component I'm less confident but it works and looks somewhat ok to my backend-focused eyes. pls merg :pray: 

- Dark mode with system/light/dark theme selector using CSS custom properties, persisted to localStorage. Fixes #5
- Read-only embed mode via ?embed=true query param with iframe embed code modal and "Edit on PocketCal" badge. Fixes #8
- Export all event groups to .ics file for Google Calendar et al. Fixes #11
- Preserve query params across URL state updates