### PR TITLE
Fix scrollbar to respect dark/light theme with purple accents

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -3,6 +3,8 @@
 	line-height: 1.5;
 	font-weight: 400;
 
+	color-scheme: light;
+
 	font-synthesis: none;
 	text-rendering: optimizeLegibility;
 	-webkit-font-smoothing: antialiased;
@@ -56,6 +58,8 @@
 }
 
 [data-theme="dark"] {
+	color-scheme: dark;
+
 	--bg-primary: #1a1a2e;
 	--bg-secondary: #1e1e3a;
 	--bg-tertiary: #252545;

--- a/src/index.css
+++ b/src/index.css
@@ -55,6 +55,10 @@
 	--icon-color: #000;
 
 	--calendar-picker-filter: brightness(0);
+
+	--scrollbar-thumb: #c4a5e6;
+	--scrollbar-thumb-hover: #b088d9;
+	--scrollbar-track: var(--bg-primary);
 }
 
 [data-theme="dark"] {
@@ -104,6 +108,34 @@
 	--icon-color: #e0e0e0;
 
 	--calendar-picker-filter: brightness(0) invert(1);
+
+	--scrollbar-thumb: #6b21a8;
+	--scrollbar-thumb-hover: #7e31bd;
+	--scrollbar-track: var(--bg-primary);
+}
+
+/* Custom scrollbar */
+* {
+	scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
+	scrollbar-width: thin;
+}
+
+*::-webkit-scrollbar {
+	width: 8px;
+	height: 8px;
+}
+
+*::-webkit-scrollbar-track {
+	background: var(--scrollbar-track);
+}
+
+*::-webkit-scrollbar-thumb {
+	background: var(--scrollbar-thumb);
+	border-radius: 4px;
+}
+
+*::-webkit-scrollbar-thumb:hover {
+	background: var(--scrollbar-thumb-hover);
 }
 
 a {


### PR DESCRIPTION
## Why

The scrollbar stays the default system color regardless of the app's theme, breaking the visual consistency of dark mode. It should blend with the background and match the app's purple accent palette.

## What changed

- Added `color-scheme: light` / `color-scheme: dark` to `:root` and `[data-theme="dark"]` so the browser uses the correct native UI appearance per theme.
- Introduced `--scrollbar-thumb`, `--scrollbar-thumb-hover`, and `--scrollbar-track` CSS variables in both light and dark palettes:
  - **Light**: light purple thumb (`#c4a5e6`) on the page background
  - **Dark**: dark purple thumb (`#6b21a8`) on the page background
- Applied custom scrollbar styles using both `scrollbar-color` (Firefox) and `::-webkit-scrollbar` pseudo-elements (Chrome/Safari) for cross-browser coverage.
- Scrollbar track uses `--bg-primary` so it blends seamlessly with the page background in both themes.