### PR TITLE
feat: add event group key to embedded calendars

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -94,3 +94,40 @@
 	opacity: 1;
 	color: white;
 }
+
+.embed-wrapper {
+	display: flex;
+	flex-direction: column;
+	height: 100vh;
+	border: 1px solid var(--border-light);
+	box-sizing: border-box;
+	border-radius: 8px;
+	overflow: hidden;
+	margin: 10px;
+}
+
+.embed-key {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 12px;
+	padding: 12px 16px;
+	background-color: var(--bg-card);
+	border-bottom: 1px solid var(--border-light);
+	align-items: center;
+	justify-content: center;
+}
+
+.embed-key-item {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 0.9em;
+	color: var(--text-primary);
+}
+
+.embed-key-item .color-indicator {
+	width: 14px;
+	height: 14px;
+	border-radius: 50%;
+	display: inline-block;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -97,7 +97,20 @@ function App() {
 		const editUrl = window.location.href.replace(/[?&]embed=true/, "");
 		return (
 			<div className="app-container embed-mode">
-				<Calendar />
+				<div className="embed-wrapper">
+					<div className="embed-key">
+						{eventGroups.map((group) => (
+							<div key={group.id} className="embed-key-item">
+								<span
+									className="color-indicator"
+									style={{ backgroundColor: group.color }}
+								></span>
+								<span className="group-name">{group.name}</span>
+							</div>
+						))}
+					</div>
+					<Calendar />
+				</div>
 				<a
 					className="embed-edit-badge"
 					href={editUrl}


### PR DESCRIPTION
This PR addresses the issue where embedded calendars lacked a key/legend for event groups. Previously, visitors viewing an embedded calendar had no way of knowing what the different calendar colors represented since the left sidebar is intentionally hidden in Embed Mode.

### 🖼️ Visual Preview

**With the New Embed Key:**
<img width="1919" height="915" alt="Light Mode Screenshot" src="https://github.com/user-attachments/assets/d37e8ec0-8ac1-4d50-bccb-89d5c8d00419" />

<img width="1919" height="910" alt="Dark Mode Screenshot" src="https://github.com/user-attachments/assets/d4f9a8e0-eee0-47c9-b90a-3a28bed94277" />

---

Fixes #20 

Added a key/legend for event groups to the embedded calendar view.

**Changes:**
- Wrapped the embedded calendar in `.embed-wrapper` with a border.
- Added an `.embed-key` header above the calendar.
- Dynamically mapped `eventGroups` to display colors and names in the key.

Tested locally across both Light and Dark modes to ensure styling parity and responsiveness!
