### PR TITLE
Add event group reordering

### DIFF
--- a/src/components/Sidebar.css
+++ b/src/components/Sidebar.css
@@ -89,6 +89,36 @@ h2 {
 	min-height: 30px;
 }
 
+.event-group-item.dragging {
+	opacity: 0.6;
+}
+
+.event-group-item.drag-over {
+	border-color: var(--drag-border);
+	box-shadow: 0 0 0 2px var(--drag-border);
+}
+
+.drag-handle {
+	color: var(--text-primary);
+	font-size: 0.75em;
+	line-height: 1;
+	padding: 4px 6px !important;
+	border: 1px solid var(--border-secondary) !important;
+	border-radius: 4px;
+	background-color: var(--bg-tertiary) !important;
+	cursor: grab !important;
+	flex-shrink: 0;
+}
+
+.drag-handle:active {
+	cursor: grabbing !important;
+}
+
+.drag-handle:disabled {
+	cursor: not-allowed !important;
+	opacity: 0.5;
+}
+
 .event-group-item .group-name {
 	flex-grow: 1;
 	overflow: hidden;
@@ -272,4 +302,16 @@ select {
 	color: var(--text-input);
 	font-size: 1em;
 	padding: 4px;
+}
+
+.sr-only {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -34,6 +34,7 @@ function Sidebar({
 		addEventGroup,
 		updateEventGroup,
 		deleteEventGroup,
+		reorderEventGroups,
 		selectEventGroup,
 		isProUser,
 		firstDayOfWeek,
@@ -44,6 +45,9 @@ function Sidebar({
 	const maxGroups = getMaxGroups(isProUser);
 	const [newEventName, setNewEventName] = useState("");
 	const [editingGroup, setEditingGroup] = useState<EventGroup | null>(null);
+	const [draggedGroupId, setDraggedGroupId] = useState<string | null>(null);
+	const [dragOverGroupId, setDragOverGroupId] = useState<string | null>(null);
+	const [reorderAnnouncement, setReorderAnnouncement] = useState("");
 	const [rawStartDate, setRawStartDate] = useState<string>(format(startDate, "yyyy-MM"))
 
 	const isValidDate = (rawDate: string): boolean => {
@@ -93,6 +97,100 @@ function Sidebar({
 		}
 	};
 
+	const announceReorder = (group: EventGroup, targetIndex: number) => {
+		setReorderAnnouncement(
+			`${group.name} moved to position ${targetIndex + 1} of ${eventGroups.length}.`
+		);
+	};
+
+	const handleDragStart = (
+		e: React.DragEvent<HTMLButtonElement>,
+		group: EventGroup
+	) => {
+		if (editingGroup) {
+			e.preventDefault();
+			return;
+		}
+
+		e.stopPropagation();
+		e.dataTransfer.effectAllowed = "move";
+		e.dataTransfer.setData("text/plain", group.id);
+		setDraggedGroupId(group.id);
+	};
+
+	const handleDragOver = (
+		e: React.DragEvent<HTMLDivElement>,
+		group: EventGroup
+	) => {
+		if (!draggedGroupId || draggedGroupId === group.id || editingGroup) {
+			return;
+		}
+
+		e.preventDefault();
+		e.dataTransfer.dropEffect = "move";
+		setDragOverGroupId(group.id);
+	};
+
+	const handleDrop = (
+		e: React.DragEvent<HTMLDivElement>,
+		targetGroup: EventGroup
+	) => {
+		e.preventDefault();
+		const droppedGroupId =
+			e.dataTransfer.getData("text/plain") || draggedGroupId;
+		const droppedGroup = eventGroups.find((group) => group.id === droppedGroupId);
+
+		if (droppedGroup && droppedGroup.id !== targetGroup.id) {
+			const targetIndex = eventGroups.findIndex(
+				(group) => group.id === targetGroup.id
+			);
+			reorderEventGroups(droppedGroup.id, targetGroup.id);
+			announceReorder(droppedGroup, targetIndex);
+		}
+
+		setDraggedGroupId(null);
+		setDragOverGroupId(null);
+	};
+
+	const handleDragLeave = (e: React.DragEvent<HTMLDivElement>) => {
+		if (e.currentTarget.contains(e.relatedTarget as Node | null)) {
+			return;
+		}
+
+		setDragOverGroupId(null);
+	};
+
+	const handleDragEnd = () => {
+		setDraggedGroupId(null);
+		setDragOverGroupId(null);
+	};
+
+	const handleReorderKeyDown = (
+		e: React.KeyboardEvent<HTMLButtonElement>,
+		group: EventGroup
+	) => {
+		e.stopPropagation();
+
+		if (editingGroup || (e.key !== "ArrowUp" && e.key !== "ArrowDown")) {
+			return;
+		}
+
+		const currentIndex = eventGroups.findIndex(
+			(eventGroup) => eventGroup.id === group.id
+		);
+		const targetIndex =
+			e.key === "ArrowUp" ? currentIndex - 1 : currentIndex + 1;
+
+		if (targetIndex < 0 || targetIndex >= eventGroups.length) {
+			e.preventDefault();
+			return;
+		}
+
+		e.preventDefault();
+		reorderEventGroups(group.id, eventGroups[targetIndex].id);
+		announceReorder(group, targetIndex);
+	};
+
 	const handleCopyUrl = () => {
 		navigator.clipboard.writeText(window.location.href);
 	};
@@ -111,7 +209,7 @@ function Sidebar({
 	};
 
 	const footerGroups = () => {
-		let proButton = (
+		const proButton = (
 			<div className="sidebar-footer-buttons">
 				<button
 					className="footer-button"
@@ -122,7 +220,7 @@ function Sidebar({
 				</button>
 			</div>
 		);
-		let copyAndHelpButtons = (
+		const copyAndHelpButtons = (
 			<div className="sidebar-footer-buttons">
 				<button
 					className="footer-button"
@@ -140,7 +238,7 @@ function Sidebar({
 				</button>
 			</div>
 		);
-		let shareButton = (
+		const shareButton = (
 			<div className="sidebar-footer-buttons">
 				<button
 					className="footer-button"
@@ -168,22 +266,43 @@ function Sidebar({
 				<CalIcon height={20} />
 				Event Groups ({eventGroups.length}/{maxGroups})
 			</h3>
+			<div className="sr-only" aria-live="polite">
+				{reorderAnnouncement}
+			</div>
 			<div className="event-groups-list" role="list">
 				{eventGroups.map((group) => (
 					<div
 						key={group.id}
 						className={`event-group-item ${
 							selectedGroupId === group.id ? "selected" : ""
-						} ${editingGroup?.id === group.id ? "editing" : ""}`}
+						} ${editingGroup?.id === group.id ? "editing" : ""} ${
+							draggedGroupId === group.id ? "dragging" : ""
+						} ${dragOverGroupId === group.id ? "drag-over" : ""}`}
 						onClick={() =>
 							editingGroup?.id !== group.id && selectEventGroup(group.id)
 						}
 						onKeyDown={(e) => handleKeyDown(e, group)}
+						onDragOver={(e) => handleDragOver(e, group)}
+						onDragLeave={handleDragLeave}
+						onDrop={(e) => handleDrop(e, group)}
 						tabIndex={editingGroup?.id !== group.id ? 0 : -1}
 						role="listitem"
 						aria-selected={selectedGroupId === group.id}
 						aria-label={`Event group: ${group.name}`}
 					>
+						<button
+							type="button"
+							className="drag-handle"
+							draggable={!editingGroup}
+							onClick={(e) => e.stopPropagation()}
+							onDragStart={(e) => handleDragStart(e, group)}
+							onDragEnd={handleDragEnd}
+							onKeyDown={(e) => handleReorderKeyDown(e, group)}
+							disabled={!!editingGroup}
+							aria-label={`Move ${group.name}. Use up and down arrow keys to reorder.`}
+						>
+							Drag
+						</button>
 						<span
 							className="color-indicator"
 							style={{ backgroundColor: group.color }}

--- a/src/store.ts
+++ b/src/store.ts
@@ -68,6 +68,7 @@ interface AppState {
 	addEventGroup: (name: string) => EventGroup;
 	updateEventGroup: (id: string, name: string) => void;
 	deleteEventGroup: (id: string) => void;
+	reorderEventGroups: (draggedId: string, targetId: string) => void;
 	selectEventGroup: (id: string | null) => void;
 	addDateRange: (groupId: string, range: DateRange) => void;
 	updateDateRange: (
@@ -210,6 +211,30 @@ export const useStore = create<AppState>((set, get) => ({
 			selectedGroupId:
 				state.selectedGroupId === id ? null : state.selectedGroupId,
 		})),
+
+	reorderEventGroups: (draggedId, targetId) =>
+		set((state) => {
+			const draggedIndex = state.eventGroups.findIndex(
+				(group) => group.id === draggedId
+			);
+			const targetIndex = state.eventGroups.findIndex(
+				(group) => group.id === targetId
+			);
+
+			if (
+				draggedIndex === -1 ||
+				targetIndex === -1 ||
+				draggedIndex === targetIndex
+			) {
+				return state;
+			}
+
+			const eventGroups = [...state.eventGroups];
+			const [draggedGroup] = eventGroups.splice(draggedIndex, 1);
+			eventGroups.splice(targetIndex, 0, draggedGroup);
+
+			return { eventGroups };
+		}),
 
 	selectEventGroup: (id) => set({ selectedGroupId: id }),
 


### PR DESCRIPTION
## Summary
- Add a store action to persist event group reordering in the shared URL state
- Add sidebar drag-and-drop reordering with visual drop feedback
- Add keyboard reordering from the drag handle with ARIA live announcements

Closes #24

## Testing
- Not run (per user instruction)
