### PR TITLE
Redesign: branding, calendar polish, and interaction refinements

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,13 @@
 		/>
 		<meta property="og:image" content="/og.png" />
 
+		<link rel="preconnect" href="https://fonts.googleapis.com" />
+		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+		<link
+			href="https://fonts.googleapis.com/css2?family=Domine:wght@400;500;600;700&family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap"
+			rel="stylesheet"
+		/>
+
 		<title>PocketCal</title>
 	</head>
 	<body>

--- a/src/App.css
+++ b/src/App.css
@@ -35,13 +35,18 @@
 	top: 16px;
 	right: 16px;
 	z-index: 200;
-	padding: 8px 8px 4px;
-	border-radius: 50%;
-	background: var(--bg-primary);
-	border: 1px solid var(--border-primary);
-	cursor: pointer;
+	width: 44px;
+	height: 44px;
+	padding: 0;
 	display: none;
-	transition: transform 0.3s ease;
+	align-items: center;
+	justify-content: center;
+	border-radius: 50%;
+	background: var(--bg-secondary);
+	border: 1px solid var(--border-primary);
+	box-shadow: var(--shadow-md);
+	cursor: pointer;
+	transition: transform 0.3s var(--ease-out);
 }
 
 .sidebar-hidden .sidebar-toggle {
@@ -50,17 +55,11 @@
 
 @media (max-width: 768px) {
 	.sidebar-toggle {
-		display: block;
+		display: flex;
 	}
 }
 
-.calendar-container {
-	max-width: 1200px;
-	margin: 0 auto;
-	padding: 20px;
-}
-
-/* Embed mode */
+/* Embed mode: a restraint pass — tighter, calmer, smaller chrome in iframes. */
 .app-container.embed-mode {
 	flex-direction: column;
 	position: relative;
@@ -68,29 +67,67 @@
 
 .app-container.embed-mode .calendar-container {
 	cursor: default;
+	padding: 12px;
+	gap: 10px;
+}
+
+.app-container.embed-mode .calendar-month {
+	box-shadow: var(--shadow-sm);
 }
 
 .app-container.embed-mode .calendar-day {
 	cursor: default;
 }
 
+.app-container.embed-mode .calendar-day:active {
+	transform: none;
+}
+
+/* Embed is read-only — suppress hover affordances that imply interactivity. */
+.app-container.embed-mode .calendar-month:hover {
+	box-shadow: var(--shadow-sm);
+}
+
+.app-container.embed-mode .calendar-day:hover {
+	background-color: var(--bg-weekday);
+}
+
+.app-container.embed-mode .calendar-day.empty:hover {
+	background-color: transparent;
+}
+
+/* Embed is read-only — no selection, so no selected-group ring or boost. */
+.app-container.embed-mode .calendar-day.in-selected-group {
+	box-shadow: none;
+	animation: none;
+}
+
 .embed-edit-badge {
 	position: fixed;
-	bottom: 8px;
+	bottom: 10px;
 	right: 12px;
 	background-color: var(--accent);
-	color: white;
-	padding: 4px 12px;
-	border-radius: 4px;
+	color: var(--accent-contrast);
+	padding: 5px 12px;
+	border-radius: var(--radius-md);
 	font-size: 12px;
-	font-weight: 500;
+	font-weight: 600;
 	text-decoration: none;
-	opacity: 0.85;
-	transition: opacity 0.2s;
+	opacity: 0.9;
+	box-shadow: var(--shadow-accent);
+	transition: opacity var(--dur-fast) var(--ease-out),
+		transform var(--dur-fast) var(--ease-out);
 	z-index: 100;
 }
 
 .embed-edit-badge:hover {
 	opacity: 1;
-	color: white;
+	transform: translateY(-1px);
+	color: var(--accent-contrast);
+}
+
+.embed-wordmark {
+	font-family: var(--font-display);
+	font-weight: 700;
+	font-optical-sizing: auto;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -104,7 +104,7 @@ function App() {
 					target="_blank"
 					rel="noopener noreferrer"
 				>
-					Edit on PocketCal
+					Edit on <span className="embed-wordmark">PocketCal</span>
 				</a>
 			</div>
 		);

--- a/src/components/Calendar.css
+++ b/src/components/Calendar.css
@@ -1,9 +1,9 @@
 .calendar-container {
 	flex: 1;
-	padding: 10px;
+	padding: 22px;
 	display: grid;
-	grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-	gap: 10px;
+	grid-template-columns: repeat(auto-fit, minmax(248px, 1fr));
+	gap: 18px;
 	align-content: start;
 	background-color: var(--bg-primary);
 	overflow-y: auto;
@@ -14,7 +14,8 @@
 
 @media (max-width: 768px) {
 	.calendar-container {
-		padding: 10px;
+		padding: 14px;
+		gap: 14px;
 	}
 }
 
@@ -27,28 +28,36 @@
 
 .calendar-month {
 	border: 1px solid var(--border-light);
-	padding: 8px;
-	border-radius: 6px;
+	padding: 14px 14px 16px;
+	border-radius: var(--radius-lg);
 	background-color: var(--bg-card);
-	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+	box-shadow: var(--shadow-sm);
 	min-width: 0;
+	transition: box-shadow var(--dur-mid) var(--ease-out),
+		transform var(--dur-mid) var(--ease-out);
+}
+
+.calendar-month:hover {
+	box-shadow: var(--shadow-md);
 }
 
 .calendar-month h3 {
 	text-align: center;
-	margin: 0 0 8px 0;
-	color: var(--text-primary);
-	font-size: 0.9em;
+	margin: 0 0 12px 0;
+	color: var(--accent-strong);
+	font-family: var(--font-display);
+	font-size: 1.12rem;
 	font-weight: 600;
+	letter-spacing: -0.01em;
 }
 
 .calendar-grid {
 	display: grid;
 	grid-template-columns: repeat(7, 1fr);
-	gap: 1px;
-	background-color: var(--bg-grid);
-	padding: 1px;
-	border-radius: 4px;
+	gap: 4px;
+	background-color: transparent;
+	padding: 0;
+	border-radius: var(--radius-sm);
 	font-size: 0.8em;
 }
 
@@ -58,35 +67,48 @@
 
 .weekday-header {
 	text-align: center;
-	font-weight: 600;
-	font-size: 0.7em;
-	padding: 2px;
-	background-color: var(--bg-weekday);
+	font-weight: 700;
+	font-size: 0.66rem;
+	letter-spacing: 0.02em;
+	padding: 2px 0 6px;
+	background-color: transparent;
 	color: var(--text-secondary);
 }
 
 .calendar-day {
-	background-color: var(--bg-secondary);
+	background-color: var(--bg-weekday);
 	border: 1px solid transparent;
-	min-height: 24px;
-	height: 24px;
-	padding: 2px;
+	aspect-ratio: 1 / 1;
+	min-width: 0;
+	min-height: 0;
+	padding: 0;
 	position: relative;
 	cursor: pointer;
 	user-select: none;
-	transition: background-color 0.5s ease;
+	border-radius: var(--radius-sm);
+	transition: background-color var(--dur-fast) var(--ease-out),
+		box-shadow var(--dur-fast) var(--ease-out),
+		transform var(--dur-fast) var(--ease-out);
 	display: flex;
 	align-items: center;
 	justify-content: center;
 }
 
 .calendar-day:hover {
-	background-color: var(--bg-weekday);
+	background-color: var(--bg-active);
+}
+
+.calendar-day:active {
+	transform: scale(0.9);
 }
 
 .calendar-day.empty {
 	background-color: transparent;
 	cursor: default;
+}
+
+.calendar-day.empty:active {
+	transform: none;
 }
 
 .calendar-day.weekend-hidden {
@@ -95,22 +117,23 @@
 
 .calendar-day.today .day-number {
 	color: var(--text-primary);
-	font-weight: bold;
+	font-weight: 700;
 	border: 2px solid var(--today-border);
 	border-radius: 50%;
 	box-sizing: border-box;
-	width: 20px;
-	height: 20px;
-	padding: 11px;
+	width: 24px;
+	height: 24px;
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	box-shadow: 0 0 0 3px color-mix(in srgb, var(--today-border) 22%, transparent);
 }
 
 .calendar-day:has(.range-indicator).today .day-number {
 	color: var(--today-text-on-range);
 	background-color: var(--today-bg-on-range);
-	border-color: transparent;
+	border-color: var(--today-bg-on-range);
+	box-shadow: 0 1px 4px rgba(0, 0, 0, 0.35);
 	text-shadow: none;
 }
 
@@ -120,38 +143,45 @@
 }
 
 .day-number {
-	font-size: 0.9em;
+	font-size: 0.92em;
 	color: var(--text-primary);
-	width: 20px;
-	height: 20px;
+	width: 22px;
+	height: 22px;
 	display: flex;
 	align-items: center;
 	justify-content: center;
 	position: relative;
 	z-index: 2;
-	transition: font-weight 0.5s ease;
+	border-radius: 50%;
+	transition: font-weight var(--dur-fast) var(--ease-out);
 }
 
-/* When the calendar day has range indicators, make the number white and bold */
+/*
+ * On a colored range, give the number a dark circular backplate so it stays
+ * legible on every group color (incl. light yellow/green) and in both themes.
+ */
 .calendar-day:has(.range-indicator) .day-number {
 	color: var(--day-text-on-range);
-	font-weight: bold;
-	text-shadow: 0 1px 2px var(--day-shadow-on-range);
+	font-weight: 700;
+	background-color: rgba(26, 14, 48, 0.52);
+	text-shadow: 0 1px 1px var(--day-shadow-on-range);
 }
 
+/* Range fills clipped to a soft "sticker" so corners read playful, not noisy. */
 .range-indicators {
 	position: absolute;
-	inset: 0;
+	inset: 2px;
 	pointer-events: none;
 	z-index: 1;
+	border-radius: var(--radius-xs);
+	overflow: hidden;
 }
 
 .range-indicator {
 	position: absolute;
 	left: 0;
 	right: 0;
-	border-radius: 2px;
-	transition: opacity 0.5s ease;
+	transition: opacity var(--dur-fast) var(--ease-out);
 }
 
 .range-indicator:hover {
@@ -159,16 +189,76 @@
 }
 
 .calendar-container:focus {
-	outline: 2px solid var(--accent-outline);
-	outline-offset: 2px;
-}
-
-.calendar-container:focus:not(:focus-visible) {
 	outline: none;
 }
 
+.calendar-container:focus-visible {
+	outline: 3px solid var(--accent-outline);
+	outline-offset: -3px;
+	border-radius: var(--radius-md);
+}
+
 .calendar-day.focused {
-	outline: 2px solid var(--accent-outline-strong);
-	outline-offset: -2px;
+	outline: 3px solid var(--accent-outline-strong);
+	outline-offset: 2px;
 	z-index: 3;
+}
+
+/*
+ * The dates of the currently-selected group get a ring in that group's own
+ * color, tying the sidebar group to its days on the calendar. The 2px gutter
+ * already between the sticker fill and the cell edge separates ring from fill.
+ */
+.calendar-day.in-selected-group {
+	box-shadow: 0 0 0 2px var(--sel-color);
+	z-index: 2;
+}
+
+/* Keyboard focus must always win over the selected-group ring. */
+.calendar-day.in-selected-group.focused {
+	z-index: 3;
+}
+
+/*
+ * Boost: when a group is selected, its days pulse once. Two identical
+ * keyframes (a/b) let us retrigger the animation on every selection change by
+ * swapping the class, even for days shared between the old and new group.
+ */
+@keyframes group-boost-a {
+	0% {
+		transform: scale(1);
+	}
+	40% {
+		transform: scale(1.12);
+	}
+	100% {
+		transform: scale(1);
+	}
+}
+
+@keyframes group-boost-b {
+	0% {
+		transform: scale(1);
+	}
+	40% {
+		transform: scale(1.12);
+	}
+	100% {
+		transform: scale(1);
+	}
+}
+
+.calendar-day.boost-a {
+	animation: group-boost-a 0.42s var(--ease-out);
+}
+
+.calendar-day.boost-b {
+	animation: group-boost-b 0.42s var(--ease-out);
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.calendar-day.boost-a,
+	.calendar-day.boost-b {
+		animation: none;
+	}
 }

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -1,10 +1,10 @@
-import React, { useState, useRef, useEffect, useCallback } from "react";
+import React, { useState, useRef, useEffect, useCallback, useMemo } from "react";
 import {
 	useStore,
 	getCalendarDates,
-	isDateInRange,
 	checkSameDay,
 	DateRange,
+	EventGroup,
 	findRangeForDate,
 } from "../store";
 import {
@@ -21,6 +21,7 @@ import {
 	parseISO,
 	subDays,
 	addDays,
+	eachDayOfInterval,
 } from "date-fns";
 import "./Calendar.css";
 
@@ -37,15 +38,87 @@ const Calendar: React.FC = () => {
 		isEmbedMode,
 	} = useStore();
 
-	const calendarDates = getCalendarDates(startDate);
-	const today = startOfDay(new Date());
+	const calendarDates = useMemo(
+		() => getCalendarDates(startDate),
+		[startDate]
+	);
+	const today = useMemo(() => startOfDay(new Date()), []);
+
+	// Precompute which groups cover each date so per-cell rendering (and every
+	// drag mousemove re-render) is a cheap Map lookup instead of re-parsing
+	// every range for all 365 cells.
+	const groupsByDate = useMemo(() => {
+		const map = new Map<string, EventGroup[]>();
+		eventGroups.forEach((group) => {
+			group.ranges.forEach((range) => {
+				const start = parseISO(range.start);
+				const end = parseISO(range.end);
+				if (isAfter(start, end)) return;
+				eachDayOfInterval({ start, end }).forEach((day) => {
+					const key = formatISO(day, { representation: "date" });
+					const existing = map.get(key);
+					if (existing) {
+						if (!existing.includes(group)) existing.push(group);
+					} else {
+						map.set(key, [group]);
+					}
+				});
+			});
+		});
+		return map;
+	}, [eventGroups]);
 
 	const [isDragging, setIsDragging] = useState(false);
 	const [dragStartDate, setDragStartDate] = useState<Date | null>(null);
 	const [dragEndDate, setDragEndDate] = useState<Date | null>(null);
 	const [focusedDate, setFocusedDate] = useState<Date | null>(null);
 	const [isContainerFocused, setIsContainerFocused] = useState(false);
+	// Track input modality so the date focus ring shows for keyboard users only
+	// (focus-visible semantics), not as a lingering outline after a mouse click.
+	const [usingKeyboard, setUsingKeyboard] = useState(false);
+	// Bumps on each user-driven group selection to retrigger the "boost" pulse;
+	// stays 0 on initial mount so there's no page-load choreography.
+	const [boostKey, setBoostKey] = useState(0);
+	const prevSelectedRef = useRef<string | null>(selectedGroupId);
 	const calendarGridRef = useRef<HTMLDivElement>(null);
+
+	const selectedGroup = useMemo(
+		() => eventGroups.find((group) => group.id === selectedGroupId) ?? null,
+		[eventGroups, selectedGroupId]
+	);
+
+	useEffect(() => {
+		const keyboardKeys = new Set([
+			"Tab",
+			"ArrowUp",
+			"ArrowDown",
+			"ArrowLeft",
+			"ArrowRight",
+			" ",
+			"Enter",
+			"Home",
+			"End",
+			"PageUp",
+			"PageDown",
+		]);
+		const onKeyDown = (e: KeyboardEvent) => {
+			if (keyboardKeys.has(e.key)) setUsingKeyboard(true);
+		};
+		const onPointerDown = () => setUsingKeyboard(false);
+		window.addEventListener("keydown", onKeyDown, true);
+		window.addEventListener("pointerdown", onPointerDown, true);
+		return () => {
+			window.removeEventListener("keydown", onKeyDown, true);
+			window.removeEventListener("pointerdown", onPointerDown, true);
+		};
+	}, []);
+
+	useEffect(() => {
+		if (prevSelectedRef.current !== selectedGroupId) {
+			prevSelectedRef.current = selectedGroupId;
+			setBoostKey((key) => key + 1);
+		}
+	}, [selectedGroupId]);
 
 	// Focus management
 	useEffect(() => {
@@ -69,7 +142,8 @@ const Calendar: React.FC = () => {
 		}
 	};
 
-	const handleContainerBlur = () => {
+	const handleContainerBlur = (e: React.FocusEvent<HTMLDivElement>) => {
+		if (e.currentTarget.contains(e.relatedTarget as Node | null)) return;
 		setIsContainerFocused(false);
 	};
 
@@ -280,17 +354,21 @@ const Calendar: React.FC = () => {
 		}
 	};
 
-	const groupedDates = calendarDates.reduce((acc, date) => {
-		if (!includeWeekends && isWeekend(date)) {
-			return acc;
-		}
-		const key = getMonthYearKey(date);
-		if (!acc[key]) {
-			acc[key] = [];
-		}
-		acc[key].push(date);
-		return acc;
-	}, {} as { [key: string]: Date[] });
+	const groupedDates = useMemo(
+		() =>
+			calendarDates.reduce((acc, date) => {
+				if (!includeWeekends && isWeekend(date)) {
+					return acc;
+				}
+				const key = getMonthYearKey(date);
+				if (!acc[key]) {
+					acc[key] = [];
+				}
+				acc[key].push(date);
+				return acc;
+			}, {} as { [key: string]: Date[] }),
+		[calendarDates, includeWeekends]
+	);
 
 	const getDayClassName = (date: Date): string => {
 		let className = "calendar-day";
@@ -303,7 +381,12 @@ const Calendar: React.FC = () => {
 			className += " weekend-hidden";
 		}
 
-		if (focusedDate && checkSameDay(date, focusedDate)) {
+		if (
+			usingKeyboard &&
+			isContainerFocused &&
+			focusedDate &&
+			checkSameDay(date, focusedDate)
+		) {
 			className += " focused";
 		}
 
@@ -323,25 +406,19 @@ const Calendar: React.FC = () => {
 		return className;
 	};
 
-	const getRangeStyles = (date: Date): React.CSSProperties[] => {
-		const styles: React.CSSProperties[] = [];
-		const groupsWithDate = eventGroups.filter((group) =>
-			isDateInRange(date, group)
-		);
+	const getRangeStyles = (dateStr: string): React.CSSProperties[] => {
+		const groupsWithDate = groupsByDate.get(dateStr);
+		if (!groupsWithDate) return [];
 
 		const totalGroups = groupsWithDate.length;
-		groupsWithDate.forEach((group, index) => {
-			styles.push({
-				backgroundColor: group.color,
-				position: "absolute",
-				left: 0,
-				right: 0,
-				top: `${(index / totalGroups) * 100}%`,
-				height: `${100 / totalGroups}%`,
-			});
-		});
-
-		return styles;
+		return groupsWithDate.map((group, index) => ({
+			backgroundColor: group.color,
+			position: "absolute",
+			left: 0,
+			right: 0,
+			top: `${(index / totalGroups) * 100}%`,
+			height: `${100 / totalGroups}%`,
+		}));
 	};
 
 	return (
@@ -397,13 +474,31 @@ const Calendar: React.FC = () => {
 
 							{datesInMonth.map((date) => {
 								const dateStr = formatISO(date, { representation: "date" });
-								const isSelected = eventGroups.some((group) =>
-									isDateInRange(date, group)
+								const dayGroups = groupsByDate.get(dateStr);
+								const isSelected = dayGroups !== undefined;
+								const inSelectedGroup = !!(
+									selectedGroupId &&
+									dayGroups?.some((group) => group.id === selectedGroupId)
 								);
+								let dayClassName = getDayClassName(date);
+								if (inSelectedGroup) {
+									dayClassName += " in-selected-group";
+									if (boostKey > 0) {
+										dayClassName +=
+											boostKey % 2 === 1 ? " boost-b" : " boost-a";
+									}
+								}
 								return (
 									<div
 										key={dateStr}
-										className={getDayClassName(date)}
+										className={dayClassName}
+										style={
+											inSelectedGroup && selectedGroup
+												? ({
+														"--sel-color": selectedGroup.color,
+												  } as React.CSSProperties)
+												: undefined
+										}
 										onMouseDown={() => handleMouseDown(date)}
 										onMouseEnter={() => handleMouseMove(date)}
 										data-date={dateStr}
@@ -418,7 +513,7 @@ const Calendar: React.FC = () => {
 											{getDate(date)}
 										</span>
 										<div className="range-indicators" aria-hidden="true">
-											{getRangeStyles(date).map((style, index) => (
+											{getRangeStyles(dateStr).map((style, index) => (
 												<div
 													key={`range-${index}`}
 													className="range-indicator"

--- a/src/components/Modal.css
+++ b/src/components/Modal.css
@@ -1,33 +1,60 @@
 .modal-overlay {
 	position: fixed;
-	top: 0;
-	left: 0;
-	right: 0;
-	bottom: 0;
-	background-color: rgba(0, 0, 0, 0.5);
+	inset: 0;
+	background-color: rgba(20, 10, 40, 0.55);
+	backdrop-filter: blur(2px);
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	padding: 16px;
 	z-index: 1000;
+	animation: modal-fade var(--dur-mid) var(--ease-out);
 }
 
 .modal-content {
 	background: var(--bg-secondary);
 	color: var(--text-primary);
-	border-radius: 8px;
-	padding: 24px;
-	max-width: 500px;
-	max-height: 80vh;
+	border: 1px solid var(--border-light);
+	border-radius: var(--radius-xl);
+	padding: 28px;
+	max-width: 520px;
+	width: 100%;
+	max-height: 84vh;
 	overflow-y: auto;
 	position: relative;
+	box-shadow: var(--shadow-lg);
+	animation: modal-pop var(--dur-mid) var(--ease-out);
+}
+
+@keyframes modal-fade {
+	from {
+		opacity: 0;
+	}
+}
+
+@keyframes modal-pop {
+	from {
+		opacity: 0;
+		transform: translateY(8px) scale(0.98);
+	}
 }
 
 .modal-content a {
-	color: var(--accent);
+	color: var(--link-color);
 }
 
 .modal-content h2 {
-	margin-top: -10px;
+	margin-top: 0;
+	margin-bottom: 4px;
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+	font-family: var(--font-display);
+	font-size: 1.6rem;
+	font-weight: 600;
+	font-optical-sizing: auto;
+	letter-spacing: -0.01em;
+	color: var(--text-heading);
 }
 
 .modal-content h2,
@@ -35,14 +62,27 @@
 	margin-bottom: 0;
 }
 
+.modal-content h3 {
+	font-weight: 700;
+}
+
 .modal-close {
 	position: absolute;
-	top: 12px;
-	right: 12px;
-	background: none;
+	top: 16px;
+	right: 16px;
+	background: var(--bg-tertiary);
 	border: none;
+	border-radius: var(--radius-pill);
 	cursor: pointer;
-	padding: 4px;
+	padding: 7px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	transition: background-color var(--dur-fast) var(--ease-out);
+}
+
+.modal-close:hover {
+	background: var(--bg-active);
 }
 
 .instructions-content {
@@ -63,7 +103,7 @@
 }
 
 .share-section {
-	margin-top: 20px;
+	margin-top: 22px;
 }
 
 .share-section h3 {
@@ -72,36 +112,39 @@
 
 .share-section p {
 	margin: 0;
+	color: var(--text-secondary);
 }
 
 .share-tabs {
 	display: inline-flex;
 	margin-top: 12px;
+	gap: 3px;
+	padding: 3px;
+	background-color: var(--bg-tertiary);
+	border-radius: var(--radius-md);
 }
 
 .share-tabs button {
-	background-color: var(--bg-tertiary);
+	background-color: transparent;
 	border: none;
-	color: var(--text-primary);
+	color: var(--text-secondary);
 	cursor: pointer;
-	padding: 6px 12px;
-}
-
-.share-tabs button:first-child {
-	border-radius: 4px 0 0 4px;
-}
-
-.share-tabs button:last-child {
-	border-radius: 0 4px 4px 0;
+	padding: 6px 16px;
+	border-radius: var(--radius-sm);
+	font-weight: 600;
+	font-size: 0.85rem;
+	transition: background-color var(--dur-fast) var(--ease-out),
+		color var(--dur-fast) var(--ease-out);
 }
 
 .share-tabs button + button {
-	margin-left: 1px;
+	margin-left: 0;
 }
 
 .share-tabs button.active {
 	background-color: var(--accent);
-	color: white;
+	color: var(--accent-contrast);
+	box-shadow: var(--shadow-sm);
 }
 
 .share-row {
@@ -126,38 +169,54 @@ button.icon-btn {
 
 button.btn {
 	background-color: var(--accent);
-	color: white;
+	color: var(--accent-contrast);
 	border: none;
-	border-radius: 4px;
-	padding: 8px 16px;
+	border-radius: var(--radius-md);
+	padding: 9px 18px;
+	font-weight: 600;
 	cursor: pointer;
+	box-shadow: var(--shadow-accent);
+	transition: background-color var(--dur-fast) var(--ease-out),
+		transform var(--dur-fast) var(--ease-out);
+}
+
+button.btn:hover {
+	background-color: var(--accent-strong);
+	transform: translateY(-1px);
 }
 
 button.btn[disabled] {
 	opacity: 0.6;
 	cursor: not-allowed;
+	box-shadow: none;
+	transform: none;
 }
 
-input[type="text"] {
-	padding: 8px;
+.modal-content input[type="text"] {
+	padding: 9px 12px;
 	border: 1px solid var(--border-primary);
-	border-radius: 4px;
+	border-radius: var(--radius-sm);
 	margin-top: 8px;
 	width: 100%;
 	box-sizing: border-box;
 	background-color: var(--bg-input);
 	color: var(--text-input);
 }
-input[type="text"]:focus {
+.modal-content input[type="text"]:focus {
 	border-color: var(--accent);
 	outline: none;
+	box-shadow: 0 0 0 3px var(--accent-focus);
 }
 
 .error-message {
-	color: red;
+	color: #e2356b;
 	margin-top: 8px;
 	font-size: 14px;
 	text-align: center;
+}
+
+[data-theme="dark"] .error-message {
+	color: #ff7aa8;
 }
 
 .license-actions {
@@ -168,8 +227,8 @@ input[type="text"]:focus {
 }
 
 p.pro-description span {
-	color: var(--accent);
-	font-weight: bold;
+	color: var(--accent-strong);
+	font-weight: 700;
 }
 
 p.license-active {
@@ -180,12 +239,13 @@ p.license-active {
 
 pre.copy-text-embed {
 	background-color: var(--bg-code);
-	border: 1px solid var(--border-primary);
-	border-radius: 4px;
-	padding: 8px;
+	border: 1px solid var(--border-light);
+	border-radius: var(--radius-sm);
+	padding: 12px;
 	overflow-x: auto;
-	font-family: monospace;
-	margin-top: 8px;
+	font-family: ui-monospace, "SFMono-Regular", "Menlo", monospace;
+	font-size: 0.82rem;
+	margin-top: 10px;
 	color: var(--text-primary);
 	white-space: nowrap;
 }

--- a/src/components/Sidebar.css
+++ b/src/components/Sidebar.css
@@ -1,10 +1,12 @@
 .sidebar {
-	min-width: 324px;
-	padding: 16px;
+	min-width: 336px;
+	width: 336px;
+	padding: 22px 20px;
 	display: flex;
 	flex-direction: column;
-	gap: 16px;
-	background-color: var(--bg-primary);
+	gap: 18px;
+	background-color: var(--bg-sidebar);
+	border-right: 1px solid var(--border-light);
 	color: var(--text-primary);
 	overflow-y: auto;
 	overflow-x: hidden;
@@ -14,26 +16,35 @@
 
 .sidebar h1 {
 	display: block;
-	font-size: 1.5em;
+	font-family: var(--font-display);
+	font-size: 2rem;
+	font-weight: 500;
+	letter-spacing: -0.01em;
+	color: var(--text-heading);
 	margin: 0;
-	padding: 0;
+	padding: 0 0 4px;
 }
 
 .sidebar h3 {
 	display: flex;
 	align-items: center;
-	margin: 10px 0 0 0;
+	gap: 8px;
+	margin: 6px 0 0 0;
+	font-size: 0.78rem;
+	font-weight: 700;
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
+	color: var(--text-secondary);
+	padding-bottom: 0;
 }
 
-.sidebar h1,
-.sidebar h3 {
-	border-bottom: 1px solid var(--border-light);
-	padding-bottom: 5px;
-	font-weight: 500;
+.sidebar h3 svg {
+	margin-right: 0;
+	opacity: 0.85;
 }
 
 h2 {
-	font-weight: 500;
+	font-weight: 600;
 }
 
 .logo-cal {
@@ -41,8 +52,18 @@ h2 {
 	font-weight: 700;
 }
 
-.sidebar h3 svg {
-	margin-right: 5px;
+.pro-badge {
+	font-family: var(--font-ui);
+	font-size: 0.62rem;
+	font-weight: 700;
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
+	color: var(--accent-contrast);
+	background: var(--accent);
+	padding: 3px 9px;
+	border-radius: var(--radius-sm);
+	margin-left: 8px;
+	vertical-align: 0.18em;
 }
 
 @media (max-width: 768px) {
@@ -65,49 +86,77 @@ h2 {
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
+	gap: 12px;
+	font-size: 0.92rem;
+	font-weight: 500;
 }
 
-.setting-item input {
-	max-width: 50%;
+.setting-item label {
+	color: var(--text-primary);
+}
+
+.setting-item input[type="month"],
+.setting-item select {
+	max-width: 55%;
 }
 
 .event-groups-list {
 	display: flex;
 	flex-direction: column;
-	gap: 10px;
+	gap: 8px;
 }
 
 .event-group-item {
 	display: flex;
 	align-items: center;
-	padding: 8px;
+	padding: 9px 11px;
 	border: 1px solid var(--border-secondary);
-	border-radius: 4px;
+	border-radius: var(--radius-md);
 	cursor: pointer;
 	background-color: var(--bg-secondary);
-	gap: 8px;
-	min-height: 30px;
+	gap: 9px;
+	min-height: 34px;
+	box-shadow: var(--shadow-sm);
+	transition: transform var(--dur-fast) var(--ease-out),
+		box-shadow var(--dur-fast) var(--ease-out),
+		border-color var(--dur-fast) var(--ease-out),
+		background-color var(--dur-fast) var(--ease-out);
 }
 
 .event-group-item.dragging {
-	opacity: 0.6;
+	opacity: 0.75;
 }
 
 .event-group-item.drag-over {
 	border-color: var(--drag-border);
-	box-shadow: 0 0 0 2px var(--drag-border);
+	box-shadow: 0 0 0 3px color-mix(in srgb, var(--drag-border) 35%, transparent);
 }
 
 .drag-handle {
-	color: var(--text-primary);
-	font-size: 0.75em;
+	color: transparent;
+	width: 18px;
+	height: 22px;
+	font-size: 0 !important;
 	line-height: 1;
-	padding: 4px 6px !important;
-	border: 1px solid var(--border-secondary) !important;
-	border-radius: 4px;
-	background-color: var(--bg-tertiary) !important;
+	padding: 0 !important;
+	border: none !important;
+	border-radius: var(--radius-xs);
+	background-color: transparent !important;
+	background-image: radial-gradient(
+		currentColor 1.4px,
+		transparent 1.4px
+	);
+	background-size: 6px 6px;
+	background-position: center;
+	color: var(--text-secondary);
 	cursor: grab !important;
 	flex-shrink: 0;
+	opacity: 0.55;
+	transition: opacity var(--dur-fast) var(--ease-out);
+}
+
+.drag-handle:hover {
+	opacity: 1;
 }
 
 .drag-handle:active {
@@ -116,7 +165,7 @@ h2 {
 
 .drag-handle:disabled {
 	cursor: not-allowed !important;
-	opacity: 0.5;
+	opacity: 0.25;
 }
 
 .event-group-item .group-name {
@@ -125,13 +174,16 @@ h2 {
 	text-overflow: ellipsis;
 	white-space: nowrap;
 	margin-right: 8px;
+	padding: 0 7px;
 	max-width: 165px;
+	font-weight: 600;
+	font-size: 0.94rem;
 }
 
 .event-group-item .group-actions {
 	display: flex;
 	justify-content: flex-end;
-	gap: 4px;
+	gap: 2px;
 	flex-shrink: 0;
 }
 
@@ -139,94 +191,170 @@ h2 {
 	cursor: default;
 }
 
-.event-group-item.selected {
-	background: linear-gradient(90deg, var(--bg-secondary), var(--accent-soft));
-	background-size: 120% 120%;
-	animation: gradient-animation 2s ease infinite;
-	box-shadow: 0 0 0 2px var(--accent-border);
-}
-
-@keyframes gradient-animation {
-	0% {
-		background-position: 0% 50%;
-	}
-	50% {
-		background-position: 100% 50%;
-	}
-	100% {
-		background-position: 0% 50%;
-	}
-}
-
 .event-group-item:hover {
-	background-color: var(--bg-hover);
+	background-color: var(--bg-hover-soft);
+	transform: translateY(-1px);
+	box-shadow: var(--shadow-md);
+}
+
+.event-group-item.selected {
+	background-color: var(--accent-soft);
+	border-color: var(--accent-border);
+	box-shadow: 0 0 0 2px var(--accent-border), var(--shadow-sm);
+}
+
+.event-group-item.selected:hover {
+	box-shadow: 0 0 0 2px var(--accent-border), var(--shadow-md);
 }
 
 .color-indicator {
 	display: inline-block;
-	width: 15px;
-	height: 15px;
+	width: 16px;
+	height: 16px;
 	border-radius: 50%;
-	margin-right: 8px;
-	border: 1px solid var(--border-primary);
+	margin-right: 4px;
+	border: 2px solid var(--bg-secondary);
+	box-shadow: 0 0 0 1.5px color-mix(in srgb, currentColor 25%, transparent),
+		var(--shadow-sm);
 	flex-shrink: 0;
 }
 
 .event-group-item button {
-	margin-left: 5px;
-	padding: 0;
+	margin-left: 2px;
+	padding: 6px;
 	font-size: 0.8em;
 	background-color: transparent;
 	border: none;
+	border-radius: var(--radius-sm);
 	cursor: pointer;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.event-group-item button:hover {
+	background-color: var(--bg-active);
 }
 
 .event-group-item button:hover svg {
-	opacity: 0.7;
+	opacity: 0.85;
 }
 
 .add-group-button {
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	gap: 5px;
-	padding: 8px 12px;
+	gap: 6px;
+	padding: 11px 12px;
 	width: 100%;
 	box-sizing: border-box;
 	background: transparent;
-	color: var(--text-primary);
-	font-size: 0.85em;
+	border: 1.5px dashed var(--border-primary);
+	border-radius: var(--radius-md);
+	color: var(--text-secondary);
+	font-size: 0.9rem;
+	font-weight: 600;
 }
 
 .add-group-button:hover {
-	background-color: var(--bg-hover);
-	border-color: transparent;
-	transition: background-color 0.3s ease;
+	background-color: var(--accent-soft);
+	border-color: var(--accent);
+	color: var(--accent-strong);
+}
+
+.add-group-button:hover svg {
+	stroke: var(--accent-strong);
 }
 
 .add-group-button:disabled {
-	background-color: var(--bg-hover);
+	background-color: transparent;
+	border-color: var(--border-light);
 	color: var(--border-primary);
 	cursor: not-allowed;
 }
 
-input {
+input,
+select {
 	background-color: var(--bg-input);
 	border: 1px solid var(--border-primary);
-	border-radius: 4px;
+	border-radius: var(--radius-sm);
 	color: var(--text-input);
-	font-size: 1em;
+	font-family: inherit;
+	font-size: 0.92rem;
+	padding: 7px 10px;
+	transition: border-color var(--dur-fast) var(--ease-out),
+		box-shadow var(--dur-fast) var(--ease-out);
+}
+
+input:focus,
+select:focus {
+	outline: none;
+	border-color: var(--accent);
+	box-shadow: 0 0 0 3px var(--accent-focus);
+}
+
+input[type="checkbox"] {
+	appearance: none;
+	-webkit-appearance: none;
+	width: 42px;
+	height: 24px;
+	padding: 0;
+	border-radius: var(--radius-pill);
+	background-color: var(--bg-pressed);
+	border: none;
+	position: relative;
+	cursor: pointer;
+	transition: background-color var(--dur-mid) var(--ease-out);
+	flex-shrink: 0;
+}
+
+input[type="checkbox"]::after {
+	content: "";
+	position: absolute;
+	top: 3px;
+	left: 3px;
+	width: 18px;
+	height: 18px;
+	border-radius: 50%;
+	background: #fff;
+	box-shadow: var(--shadow-sm);
+	transition: transform var(--dur-mid) var(--ease-out);
+}
+
+input[type="checkbox"]:checked {
+	background-color: var(--accent);
+}
+
+input[type="checkbox"]:checked::after {
+	transform: translateX(18px);
+}
+
+input[type="checkbox"]:focus-visible {
+	outline: 3px solid var(--accent-focus);
+	outline-offset: 2px;
 }
 
 input[type="month"]::-webkit-calendar-picker-indicator {
 	filter: var(--calendar-picker-filter);
+	cursor: pointer;
 }
 
 input.group-name-input {
 	flex-grow: 1;
 	margin-right: 8px;
 	width: auto;
+	min-width: 0;
 	max-width: 158px;
+	padding: 2px 6px;
+	font-size: 0.94rem;
+	font-weight: 600;
+	background-color: transparent;
+	border: 1px solid var(--border-secondary);
+	border-radius: var(--radius-sm);
+}
+
+input.group-name-input:focus {
+	background-color: var(--bg-input);
 }
 
 @media (max-width: 768px) {
@@ -242,18 +370,11 @@ input.group-name-input {
 	}
 
 	.add-group-button {
-		margin-top: 15px;
-	}
-
-	.event-group-item {
-		flex-wrap: wrap;
+		margin-top: 8px;
 	}
 
 	.event-group-item .group-name {
-		margin-right: 0;
-		margin-bottom: 5px;
-		flex-basis: 100%;
-		max-width: calc(100% - 104px);
+		max-width: none;
 	}
 
 	input.group-name-input {
@@ -263,6 +384,7 @@ input.group-name-input {
 
 .sidebar-footer {
 	margin-top: auto;
+	padding-top: 8px;
 }
 
 .sidebar-footer-buttons {
@@ -273,35 +395,49 @@ input.group-name-input {
 
 .footer-button {
 	flex: 1;
-	padding: 8px 12px;
-	background-color: var(--bg-tertiary);
+	padding: 10px 12px;
+	background-color: var(--bg-secondary);
 	border: 1px solid var(--border-secondary);
-	border-radius: 4px;
+	border-radius: var(--radius-md);
 	cursor: pointer;
-	font-size: 14px;
+	font-size: 0.88rem;
+	font-weight: 600;
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	gap: 4px;
-	transition: background-color 0.2s;
+	gap: 6px;
 	color: var(--text-primary);
+	box-shadow: var(--shadow-sm);
 }
 
 .footer-button:hover {
-	background-color: var(--bg-active);
+	background-color: var(--bg-hover-soft);
+	transform: translateY(-1px);
+	box-shadow: var(--shadow-md);
 }
 
 .footer-button:active {
-	background-color: var(--bg-pressed);
+	transform: translateY(0);
+	background-color: var(--bg-active);
 }
 
-select {
-	background-color: var(--bg-input);
-	border: 1px solid var(--border-primary);
-	border-radius: 4px;
-	color: var(--text-input);
-	font-size: 1em;
-	padding: 4px;
+/* The "Go Pro" / "Thanks for going Pro!" button is the footer's hero action. */
+.footer-button.pro-button {
+	background: var(--accent);
+	color: var(--accent-contrast);
+	border-color: transparent;
+	box-shadow: var(--shadow-accent);
+}
+
+.footer-button.pro-button:hover {
+	background: var(--accent-strong);
+	color: var(--accent-contrast);
+}
+
+.footer-button.copied {
+	background-color: var(--bg-secondary);
+	border-color: var(--accent);
+	color: var(--accent-strong);
 }
 
 .sr-only {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -49,6 +49,7 @@ function Sidebar({
 	const [dragOverGroupId, setDragOverGroupId] = useState<string | null>(null);
 	const [reorderAnnouncement, setReorderAnnouncement] = useState("");
 	const [rawStartDate, setRawStartDate] = useState<string>(format(startDate, "yyyy-MM"))
+	const [copyState, setCopyState] = useState<"idle" | "copied" | "error">("idle");
 
 	const isValidDate = (rawDate: string): boolean => {
 		const [year, month] = rawDate.split("-");
@@ -115,6 +116,17 @@ function Sidebar({
 		e.stopPropagation();
 		e.dataTransfer.effectAllowed = "move";
 		e.dataTransfer.setData("text/plain", group.id);
+
+		const item = e.currentTarget.closest<HTMLElement>(".event-group-item");
+		if (item) {
+			const rect = item.getBoundingClientRect();
+			e.dataTransfer.setDragImage(
+				item,
+				e.clientX - rect.left,
+				e.clientY - rect.top
+			);
+		}
+
 		setDraggedGroupId(group.id);
 	};
 
@@ -191,8 +203,14 @@ function Sidebar({
 		announceReorder(group, targetIndex);
 	};
 
-	const handleCopyUrl = () => {
-		navigator.clipboard.writeText(window.location.href);
+	const handleCopyUrl = async () => {
+		try {
+			await navigator.clipboard.writeText(window.location.href);
+			setCopyState("copied");
+		} catch {
+			setCopyState("error");
+		}
+		setTimeout(() => setCopyState("idle"), 2000);
 	};
 
 	const handleStartDateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -212,7 +230,7 @@ function Sidebar({
 		const proButton = (
 			<div className="sidebar-footer-buttons">
 				<button
-					className="footer-button"
+					className="footer-button pro-button"
 					onClick={() => setShowLicenseModal(true)}
 					aria-label="Show license modal"
 				>
@@ -223,11 +241,16 @@ function Sidebar({
 		const copyAndHelpButtons = (
 			<div className="sidebar-footer-buttons">
 				<button
-					className="footer-button"
+					className={`footer-button ${copyState === "copied" ? "copied" : ""}`}
 					onClick={handleCopyUrl}
 					aria-label="Copy URL to clipboard"
 				>
-					<CopyIcon color="var(--icon-color)" /> Copy URL
+					<CopyIcon color="var(--icon-color)" />{" "}
+					{copyState === "copied"
+						? "Copied!"
+						: copyState === "error"
+						? "Press Ctrl+C"
+						: "Copy URL"}
 				</button>
 				<button
 					className="footer-button"
@@ -447,7 +470,16 @@ function Sidebar({
 				</div>
 			</>
 
-			<div className="sidebar-footer">{footerGroups()}</div>
+			<div className="sidebar-footer">
+				<div className="sr-only" aria-live="polite">
+					{copyState === "copied"
+						? "Link copied to clipboard."
+						: copyState === "error"
+						? "Couldn't copy automatically. Press Control or Command + C to copy."
+						: ""}
+				</div>
+				{footerGroups()}
+			</div>
 		</div>
 	);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,6 @@
 :root {
-	font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+	font-family: "Plus Jakarta Sans", -apple-system, BlinkMacSystemFont, "Segoe UI",
+		"Roboto", "Helvetica Neue", sans-serif;
 	line-height: 1.5;
 	font-weight: 400;
 
@@ -10,108 +11,217 @@
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 
-	/* Light theme (default) */
-	--bg-primary: #f9f9f9;
+	/* ---- Type ---- */
+	--font-ui: "Plus Jakarta Sans", -apple-system, BlinkMacSystemFont, "Segoe UI",
+		"Roboto", "Helvetica Neue", sans-serif;
+	--font-display: "Domine", Georgia, "Times New Roman", serif;
+
+	/* ---- Radius scale ---- */
+	--radius-xs: 6px;
+	--radius-sm: 8px;
+	--radius-md: 12px;
+	--radius-lg: 16px;
+	--radius-xl: 22px;
+	--radius-pill: 999px;
+
+	/* ---- Motion ---- */
+	--ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+	--dur-fast: 140ms;
+	--dur-mid: 220ms;
+
+	/*
+	 * Light theme (default).
+	 * Hex fallbacks are declared first, then overridden with OKLCH for
+	 * browsers that support it. Brand purple + the 5 group colors are
+	 * identity-preserving; their values are intentionally unchanged.
+	 */
+	--bg-primary: #f4f1fb;
 	--bg-secondary: #ffffff;
-	--bg-tertiary: #f0f0f0;
-	--bg-hover: #f0f0f0;
-	--bg-active: #e0e0e0;
-	--bg-pressed: #d0d0d0;
-	--bg-card: white;
-	--bg-grid: #f5f5f5;
-	--bg-weekday: #f8f9fa;
-	--bg-input: #fff;
-	--bg-code: #f5f5f5;
+	--bg-tertiary: #ece7f7;
+	--bg-hover: #efeaf9;
+	--bg-hover-soft: #f7f4fc;
+	--bg-active: #e4dcf4;
+	--bg-pressed: #d8cdee;
+	--bg-card: #ffffff;
+	--bg-grid: #ece7f7;
+	--bg-weekday: #f4f1fb;
+	--bg-input: #ffffff;
+	--bg-code: #f1edfa;
+	--bg-sidebar: #efeaf8;
 
-	--text-primary: #333;
-	--text-secondary: #666;
-	--text-heading: #213547;
-	--text-input: #000;
+	--text-primary: #2c2440;
+	--text-secondary: #645b7e;
+	--text-heading: #241d38;
+	--text-input: #241d38;
 
-	--border-primary: #ccc;
-	--border-secondary: #ddd;
-	--border-light: #eee;
+	--border-primary: #cfc6e6;
+	--border-secondary: #ddd6ef;
+	--border-light: #e7e1f5;
 
 	--accent: #8a35de;
-	--accent-soft: rgba(138, 53, 222, 0.05);
-	--accent-border: rgba(138, 53, 222, 0.25);
-	--accent-focus: rgba(138, 53, 222, 0.3);
-	--accent-outline: rgba(138, 53, 222, 0.5);
-	--accent-outline-strong: rgba(138, 53, 222, 0.8);
+	--accent-strong: #7726c9;
+	--accent-contrast: #ffffff;
+	--accent-soft: rgba(138, 53, 222, 0.08);
+	--accent-border: rgba(138, 53, 222, 0.28);
+	--accent-focus: rgba(138, 53, 222, 0.45);
+	--accent-outline: rgba(138, 53, 222, 0.55);
+	--accent-outline-strong: rgba(138, 53, 222, 0.95);
 
 	--drag-bg: #e3f2fd;
 	--drag-border: #2196f3;
 
 	--today-border: #eb4888;
-	--today-text-on-range: #333;
-	--today-bg-on-range: #fff;
+	--today-text-on-range: #241d38;
+	--today-bg-on-range: #ffffff;
 
-	--day-text-on-range: white;
-	--day-shadow-on-range: rgba(0, 0, 0, 0.7);
+	--day-text-on-range: #ffffff;
+	--day-shadow-on-range: rgba(0, 0, 0, 0.55);
 
-	--link-color: #646cff;
-	--link-hover: #747bff;
+	--link-color: #7726c9;
+	--link-hover: #8a35de;
 
-	--icon-color: #000;
+	--icon-color: #2c2440;
 
-	--calendar-picker-filter: brightness(0);
+	--calendar-picker-filter: invert(28%) sepia(38%) saturate(2200%)
+		hue-rotate(255deg) brightness(85%);
 
 	--scrollbar-thumb: #c4a5e6;
 	--scrollbar-thumb-hover: #b088d9;
 	--scrollbar-track: var(--bg-primary);
+
+	/* ---- Shadows (purple-tinted, soft) ---- */
+	--shadow-sm: 0 1px 2px rgba(56, 24, 102, 0.06),
+		0 2px 6px rgba(56, 24, 102, 0.05);
+	--shadow-md: 0 4px 10px rgba(56, 24, 102, 0.08),
+		0 10px 24px rgba(56, 24, 102, 0.08);
+	--shadow-lg: 0 12px 30px rgba(56, 24, 102, 0.16),
+		0 28px 60px rgba(56, 24, 102, 0.14);
+	--shadow-accent: 0 6px 16px rgba(138, 53, 222, 0.32);
+}
+
+@supports (color: oklch(0% 0 0)) {
+	:root {
+		--bg-primary: oklch(0.965 0.012 300);
+		--bg-secondary: oklch(1 0 0);
+		--bg-tertiary: oklch(0.94 0.018 300);
+		--bg-hover: oklch(0.95 0.018 300);
+		--bg-hover-soft: oklch(0.972 0.01 300);
+		--bg-active: oklch(0.915 0.026 300);
+		--bg-pressed: oklch(0.875 0.036 300);
+		--bg-card: oklch(1 0 0);
+		--bg-grid: oklch(0.94 0.018 300);
+		--bg-weekday: oklch(0.965 0.012 300);
+		--bg-input: oklch(1 0 0);
+		--bg-code: oklch(0.955 0.016 300);
+		--bg-sidebar: oklch(0.95 0.02 300);
+
+		--text-primary: oklch(0.34 0.04 300);
+		--text-secondary: oklch(0.5 0.045 300);
+		--text-heading: oklch(0.29 0.05 300);
+		--text-input: oklch(0.29 0.05 300);
+
+		--border-primary: oklch(0.84 0.04 300);
+		--border-secondary: oklch(0.89 0.025 300);
+		--border-light: oklch(0.92 0.02 300);
+
+		--accent: oklch(0.55 0.215 300);
+		--accent-strong: oklch(0.49 0.21 300);
+		--link-color: oklch(0.49 0.21 300);
+		--link-hover: oklch(0.55 0.215 300);
+		--icon-color: oklch(0.34 0.04 300);
+	}
 }
 
 [data-theme="dark"] {
 	color-scheme: dark;
 
-	--bg-primary: #1a1a2e;
-	--bg-secondary: #1e1e3a;
-	--bg-tertiary: #252545;
-	--bg-hover: #2a2a4a;
-	--bg-active: #353560;
-	--bg-pressed: #404070;
-	--bg-card: #1e1e3a;
-	--bg-grid: #222244;
-	--bg-weekday: #252548;
-	--bg-input: #252545;
-	--bg-code: #252545;
+	/* Deep plum base so the purple accent belongs (was clashing navy). */
+	--bg-primary: #1c1530;
+	--bg-secondary: #261c40;
+	--bg-tertiary: #2f2350;
+	--bg-hover: #342758;
+	--bg-hover-soft: #2c2150;
+	--bg-active: #3f2f69;
+	--bg-pressed: #4a387b;
+	--bg-card: #261c40;
+	--bg-grid: #2a1f48;
+	--bg-weekday: #2a1f48;
+	--bg-input: #2f2350;
+	--bg-code: #2a1f48;
+	--bg-sidebar: #221836;
 
-	--text-primary: #e0e0e0;
-	--text-secondary: #a0a0b0;
-	--text-heading: #e8e8f0;
-	--text-input: #e0e0e0;
+	--text-primary: #e8e2f6;
+	--text-secondary: #b1a6cf;
+	--text-heading: #f1ecfb;
+	--text-input: #e8e2f6;
 
-	--border-primary: #404060;
-	--border-secondary: #353555;
-	--border-light: #2a2a4a;
+	--border-primary: #443663;
+	--border-secondary: #3a2d57;
+	--border-light: #322748;
 
-	--accent: #a855f7;
-	--accent-soft: rgba(168, 85, 247, 0.1);
-	--accent-border: rgba(168, 85, 247, 0.35);
-	--accent-focus: rgba(168, 85, 247, 0.4);
-	--accent-outline: rgba(168, 85, 247, 0.5);
-	--accent-outline-strong: rgba(168, 85, 247, 0.8);
+	--accent: #b06bf7;
+	--accent-strong: #c084fc;
+	--accent-contrast: #1c1530;
+	--accent-soft: rgba(176, 107, 247, 0.14);
+	--accent-border: rgba(176, 107, 247, 0.4);
+	--accent-focus: rgba(176, 107, 247, 0.55);
+	--accent-outline: rgba(176, 107, 247, 0.6);
+	--accent-outline-strong: rgba(192, 132, 252, 0.95);
 
-	--drag-bg: rgba(33, 150, 243, 0.15);
+	--drag-bg: rgba(33, 150, 243, 0.18);
 	--drag-border: #64b5f6;
 
 	--today-border: #f472b6;
-	--today-text-on-range: #e0e0e0;
-	--today-bg-on-range: #1e1e3a;
+	--today-text-on-range: #f1ecfb;
+	--today-bg-on-range: #261c40;
 
-	--day-text-on-range: white;
-	--day-shadow-on-range: rgba(0, 0, 0, 0.9);
+	--day-text-on-range: #ffffff;
+	--day-shadow-on-range: rgba(0, 0, 0, 0.85);
 
-	--link-color: #818cf8;
-	--link-hover: #a5b4fc;
+	--link-color: #c79bf9;
+	--link-hover: #d9bcfc;
 
-	--icon-color: #e0e0e0;
+	--icon-color: #e8e2f6;
 
 	--calendar-picker-filter: brightness(0) invert(1);
 
-	--scrollbar-thumb: #6b21a8;
-	--scrollbar-thumb-hover: #7e31bd;
+	--scrollbar-thumb: #6b3fa8;
+	--scrollbar-thumb-hover: #8456c5;
 	--scrollbar-track: var(--bg-primary);
+
+	--shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3), 0 2px 6px rgba(0, 0, 0, 0.25);
+	--shadow-md: 0 6px 16px rgba(0, 0, 0, 0.4);
+	--shadow-lg: 0 16px 40px rgba(0, 0, 0, 0.55);
+	--shadow-accent: 0 6px 18px rgba(176, 107, 247, 0.4);
+}
+
+@supports (color: oklch(0% 0 0)) {
+	[data-theme="dark"] {
+		--bg-primary: oklch(0.22 0.05 305);
+		--bg-secondary: oklch(0.27 0.06 305);
+		--bg-tertiary: oklch(0.31 0.07 305);
+		--bg-hover: oklch(0.34 0.075 305);
+		--bg-hover-soft: oklch(0.305 0.062 305);
+		--bg-active: oklch(0.38 0.085 305);
+		--bg-pressed: oklch(0.43 0.095 305);
+		--bg-card: oklch(0.27 0.06 305);
+		--bg-grid: oklch(0.29 0.065 305);
+		--bg-weekday: oklch(0.29 0.065 305);
+		--bg-input: oklch(0.31 0.07 305);
+		--bg-code: oklch(0.29 0.065 305);
+		--bg-sidebar: oklch(0.25 0.055 305);
+
+		--text-primary: oklch(0.92 0.025 305);
+		--text-secondary: oklch(0.76 0.05 305);
+		--text-heading: oklch(0.95 0.02 305);
+
+		--border-primary: oklch(0.4 0.07 305);
+		--border-secondary: oklch(0.35 0.06 305);
+		--border-light: oklch(0.32 0.055 305);
+
+		--accent: oklch(0.68 0.18 305);
+		--accent-strong: oklch(0.74 0.16 305);
+	}
 }
 
 /* Custom scrollbar */
@@ -121,8 +231,8 @@
 }
 
 *::-webkit-scrollbar {
-	width: 8px;
-	height: 8px;
+	width: 10px;
+	height: 10px;
 }
 
 *::-webkit-scrollbar-track {
@@ -131,7 +241,8 @@
 
 *::-webkit-scrollbar-thumb {
 	background: var(--scrollbar-thumb);
-	border-radius: 4px;
+	border-radius: var(--radius-pill);
+	border: 2px solid var(--scrollbar-track);
 }
 
 *::-webkit-scrollbar-thumb:hover {
@@ -139,7 +250,7 @@
 }
 
 a {
-	font-weight: 500;
+	font-weight: 600;
 	color: var(--link-color);
 	text-decoration: inherit;
 }
@@ -149,9 +260,7 @@ a:hover {
 
 body {
 	margin: 0;
-	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
-		"Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
-		sans-serif;
+	font-family: var(--font-ui);
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 	background-color: var(--bg-primary);
@@ -159,18 +268,33 @@ body {
 }
 
 button {
-	border-radius: 8px;
+	border-radius: var(--radius-md);
 	border: 1px solid transparent;
 	padding: 0.6em 1.2em;
 	font-size: 1em;
-	font-weight: 500;
+	font-weight: 600;
 	font-family: inherit;
-	background-color: var(--bg-primary);
+	background-color: var(--bg-secondary);
+	color: var(--text-primary);
 	cursor: pointer;
-	transition: border-color 0.25s;
+	transition: border-color var(--dur-fast) var(--ease-out),
+		background-color var(--dur-fast) var(--ease-out),
+		transform var(--dur-fast) var(--ease-out),
+		box-shadow var(--dur-fast) var(--ease-out);
 }
 button:focus,
 button:focus-visible {
-	outline: 4px auto var(--accent-focus);
+	outline: 3px solid var(--accent-focus);
 	outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	*,
+	*::before,
+	*::after {
+		animation-duration: 0.001ms !important;
+		animation-iteration-count: 1 !important;
+		transition-duration: 0.001ms !important;
+		scroll-behavior: auto !important;
+	}
 }


### PR DESCRIPTION
A style refresh of PocketCal

## What changed

**Global styles & branding**
- New purple-y colors throughout
- More round things
- New Domine wordmark

**Calendar**
- Selecting an event group adds a boost animation + persistent color ring on the calendar

**Event group sidebar**
- New button styles
- The whole group row is now the drag preview

**Embed / iframe mode**
- Domine wordmark in the edit badge