### PR TITLE
Fix pro badge height in header

### DIFF
--- a/src/components/Sidebar.css
+++ b/src/components/Sidebar.css
@@ -64,7 +64,7 @@ h2 {
 	font-family: var(--font-ui);
 	font-size: 0.62rem;
 	font-weight: 700;
-	line-height: 1;
+	line-height: 1.3;
 	letter-spacing: 0.04em;
 	text-transform: uppercase;
 	color: var(--accent-contrast);

--- a/src/components/Sidebar.css
+++ b/src/components/Sidebar.css
@@ -64,6 +64,7 @@ h2 {
 	font-family: var(--font-ui);
 	font-size: 0.62rem;
 	font-weight: 700;
+	line-height: 1;
 	letter-spacing: 0.04em;
 	text-transform: uppercase;
 	color: var(--accent-contrast);
@@ -71,7 +72,6 @@ h2 {
 	padding: 3px 9px;
 	border-radius: var(--radius-sm);
 	margin-left: 8px;
-	margin-bottom: 0.35em;
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
The .pro-badge span inherited the header's 32px line-height. Because .sidebar h1 is a flex container, that inherited line-height inflated the badge's flex-item height (and thus the whole header), even though the badge's font-size is tiny. In the license modal the badge sits in a non-flex h2, where line-height doesn't affect an inline element's box height, so it looked correct there.

Set line-height: 1 on .pro-badge and drop the now-unnecessary margin-bottom (it only existed to nudge baseline alignment, and had no effect in the modal's inline context anyway; keeping it in the flex header just added extra height).